### PR TITLE
Add In-Memory Cache for getSiteGeoJSON

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
@@ -16,11 +16,7 @@ public class RecordStewardshipRequest extends ApiDto {
   private boolean weeded;
 
   public RecordStewardshipRequest(
-      java.sql.Date date,
-      boolean watered,
-      boolean mulched,
-      boolean cleaned,
-      boolean weeded) {
+      java.sql.Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded) {
     this.date = date;
     this.watered = watered;
     this.mulched = mulched;


### PR DESCRIPTION
## Why
calling `getSiteGeoJson()` takes about 5000ms when load tested on @willmt80 's computer with ~11,000 sites. When called multiple times in succession the Vert.x event loop is blocked (basically it suffers the same problem as node.js when the app is running on a single verticle). Each 5000ms request gets queued up and eventually the event loop gets too backed up and some requests get dropped.

By keeping an in-memory cache of previous results with a TTL of 1-2 times the mean response time, we get rid of "queueing" problem, which means nothing will get backed up and we shouldn't get dropped requests.

## How
I create a private cache class for the map processor (we could make it generic if we wanted but we only cache in one place so 🤷 ) and give it an expiry date. In `getSiteGeoJson()` we first check if the cache contains fresh data and if so we use that, otherwise we update the cache and set the expiry date to `System.currentTimeMillis() + timeToLive`.

## Verification
@willmt80 needs to run a load tester to see if we actually get any dropped requests. The following command should be run and the console should be observed for any errors:

```sh
# Test 1 
loadtest -n 100  http://localhost:8081/api/v1/map/sites
# Test 2 (concurrent requests)
loadtest -n 100 -c 10 http://localhost:8081/api/v1/map/sites
# Test 3 (total successful requests per minute)
loadtest -t 60000 http://localhost:8081/api/v1/map/sites
# Test 4 (stress test: 200 requests per second from 10 concurrent users)
loadtest -c 10 --rps 200 -t 60000 http://localhost:8081/api/v1/map/sites
```
Please report the loadtest results for each of the 4 tests!
