### PR TITLE
Improve get site map performance

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/map/SiteFeatureProperties.java
+++ b/api/src/main/java/com/codeforcommunity/dto/map/SiteFeatureProperties.java
@@ -18,22 +18,12 @@ public class SiteFeatureProperties {
   public SiteFeatureProperties(
       Integer id,
       Boolean treePresent,
-      Double diameter,
-      String species,
-      Timestamp updatedAt,
       Date plantingDate,
-      String updatedBy,
-      Integer adopterId,
-      String address) {
+      Integer adopterId) {
     this.id = id;
     this.treePresent = treePresent;
-    this.diameter = diameter;
-    this.species = species;
-    this.updatedAt = updatedAt;
     this.plantingDate = plantingDate;
-    this.updatedBy = updatedBy;
     this.adopterId = adopterId;
-    this.address = address;
   }
 
   public Integer getId() {
@@ -53,25 +43,11 @@ public class SiteFeatureProperties {
     return species;
   }
 
-  @JsonProperty("updated_at")
-  public Timestamp getUpdatedAt() {
-    return updatedAt;
-  }
-
-  @JsonProperty("updated_by")
-  public String getUpdatedBy() {
-    return updatedBy;
-  }
-
   public String getAddress() {
     return address;
   }
 
   public Date getPlantingDate() {
     return plantingDate;
-  }
-
-  public Integer getAdopterId() {
-    return adopterId;
   }
 }

--- a/api/src/main/java/com/codeforcommunity/dto/map/SiteFeatureProperties.java
+++ b/api/src/main/java/com/codeforcommunity/dto/map/SiteFeatureProperties.java
@@ -2,24 +2,17 @@ package com.codeforcommunity.dto.map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.sql.Date;
-import java.sql.Timestamp;
 
 public class SiteFeatureProperties {
   Integer id;
   Boolean treePresent;
   Double diameter;
   String species;
-  Timestamp updatedAt;
   Date plantingDate;
-  String updatedBy; // username
   Integer adopterId;
-  String address;
 
   public SiteFeatureProperties(
-      Integer id,
-      Boolean treePresent,
-      Date plantingDate,
-      Integer adopterId) {
+      Integer id, Boolean treePresent, Date plantingDate, Integer adopterId) {
     this.id = id;
     this.treePresent = treePresent;
     this.plantingDate = plantingDate;
@@ -41,10 +34,6 @@ public class SiteFeatureProperties {
 
   public String getSpecies() {
     return species;
-  }
-
-  public String getAddress() {
-    return address;
   }
 
   public Date getPlantingDate() {

--- a/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
@@ -2,7 +2,6 @@ package com.codeforcommunity.processor;
 
 import static org.jooq.generated.tables.AdoptedSites.ADOPTED_SITES;
 import static org.jooq.generated.tables.Blocks.BLOCKS;
-import static org.jooq.generated.tables.EntryUsernames.ENTRY_USERNAMES;
 import static org.jooq.generated.tables.Neighborhoods.NEIGHBORHOODS;
 import static org.jooq.generated.tables.Reservations.RESERVATIONS;
 import static org.jooq.generated.tables.SiteEntries.SITE_ENTRIES;
@@ -26,15 +25,13 @@ import com.codeforcommunity.logger.SLogger;
 import io.vertx.core.json.JsonObject;
 import java.math.BigDecimal;
 import java.sql.Date;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.jooq.DSLContext;
-import org.jooq.Record4;
-import org.jooq.Record6;
 import org.jooq.Record2;
+import org.jooq.Record6;
 import org.jooq.Result;
 import org.jooq.Select;
 import org.jooq.generated.tables.records.BlocksRecord;
@@ -140,10 +137,7 @@ public class MapProcessorImpl implements IMapProcessor {
           sitesRecord) {
     SiteFeatureProperties properties =
         new SiteFeatureProperties(
-            sitesRecord.value1(),
-            sitesRecord.value2(),
-            sitesRecord.value3(),
-            sitesRecord.value4());
+            sitesRecord.value1(), sitesRecord.value2(), sitesRecord.value3(), sitesRecord.value4());
     GeometryPoint geometry = new GeometryPoint(sitesRecord.value5(), sitesRecord.value6());
     return new SiteFeature(properties, geometry);
   }
@@ -211,7 +205,7 @@ public class MapProcessorImpl implements IMapProcessor {
                 Integer, // Adopter User ID
                 BigDecimal, // Lat
                 BigDecimal>> // Lng
-            allSiteEntriesRecords =
+        allSiteEntriesRecords =
             this.db
                 .select(
                     SITES.ID,
@@ -226,13 +220,12 @@ public class MapProcessorImpl implements IMapProcessor {
                 .innerJoin(SITE_ENTRIES)
                 .on(SITES.ID.eq(SITE_ENTRIES.SITE_ID))
                 .where(
-                        SITE_ENTRIES.UPDATED_AT.in(
-                                this.db
-                                        .select(max(SITE_ENTRIES.UPDATED_AT))
-                                        .from(SITE_ENTRIES)
-                                        .groupBy(SITE_ENTRIES.SITE_ID)
-                                        .fetch()))
-
+                    SITE_ENTRIES.UPDATED_AT.in(
+                        this.db
+                            .select(max(SITE_ENTRIES.UPDATED_AT))
+                            .from(SITE_ENTRIES)
+                            .groupBy(SITE_ENTRIES.SITE_ID)
+                            .fetch()))
                 .orderBy(SITES.ID)
                 .fetch();
 


### PR DESCRIPTION
Removed one of the joins and some of the selected fields from the getSiteGeoJson request to improve performance.

Old Latency:
![current-latency](https://user-images.githubusercontent.com/19194912/121789784-ead88480-cba6-11eb-9cd1-bb95b0f5c4fd.PNG)

New Latency:
![new-latency](https://user-images.githubusercontent.com/19194912/121789795-0774bc80-cba7-11eb-83e1-751b05830333.PNG)


Not a crazy improvement but still significant