### PR TITLE
Site entries are ordered from most to least recent

### DIFF
--- a/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
@@ -39,7 +39,7 @@ public class SiteProcessorImpl implements ISiteProcessor {
     List<SiteEntriesRecord> records =
         db.selectFrom(SITE_ENTRIES)
             .where(SITE_ENTRIES.SITE_ID.eq(siteId))
-            .orderBy(SITE_ENTRIES.UPDATED_AT)
+            .orderBy(SITE_ENTRIES.UPDATED_AT.desc())
             .fetch();
 
     List<SiteEntry> siteEntries = new ArrayList<>();


### PR DESCRIPTION
Closes #65.

Changed the query, made sure frontend shows the most recent site on the tree page:
Before
![image](https://user-images.githubusercontent.com/22990100/125002067-1f165800-e022-11eb-8aae-0a1eed264a54.png)
After
![image](https://user-images.githubusercontent.com/22990100/125002055-16258680-e022-11eb-9f51-360c1f006d8f.png)
