### PR TITLE
Unique site entries on map

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/map/SiteFeatureProperties.java
+++ b/api/src/main/java/com/codeforcommunity/dto/map/SiteFeatureProperties.java
@@ -1,6 +1,5 @@
 package com.codeforcommunity.dto.map;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.sql.Date;
 
 public class SiteFeatureProperties {

--- a/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
@@ -7,8 +7,8 @@ import static org.jooq.generated.tables.Reservations.RESERVATIONS;
 import static org.jooq.generated.tables.SiteEntries.SITE_ENTRIES;
 import static org.jooq.generated.tables.Sites.SITES;
 import static org.jooq.impl.DSL.count;
-import static org.jooq.impl.DSL.table;
 import static org.jooq.impl.DSL.max;
+import static org.jooq.impl.DSL.table;
 
 import com.codeforcommunity.api.IMapProcessor;
 import com.codeforcommunity.dto.map.BlockFeature;
@@ -37,7 +37,6 @@ import org.jooq.Record8;
 import org.jooq.Result;
 import org.jooq.Select;
 import org.jooq.Table;
-import org.jooq.generated.tables.SiteEntries;
 import org.jooq.generated.tables.records.BlocksRecord;
 import org.jooq.generated.tables.records.NeighborhoodsRecord;
 
@@ -180,32 +179,39 @@ public class MapProcessorImpl implements IMapProcessor {
 
     Field<Timestamp> maxDate = max(SITE_ENTRIES.UPDATED_AT).as("MaxDate");
 
-    Table<Record2<
-              Integer, // Site Entry ID
-              Timestamp // Updated_At
-            >> recentlyUpdated = table(
-                    this.db.select(
-                            SITE_ENTRIES.SITE_ID,
-                            maxDate
-                    ).from(SITE_ENTRIES)
-                    .groupBy(SITE_ENTRIES.SITE_ID)
-    ).as("recentlyUpdated");
+    Table<
+            Record2<
+                Integer, // Site Entry ID
+                Timestamp // Updated_At
+            >>
+        recentlyUpdated =
+            table(
+                    this.db
+                        .select(SITE_ENTRIES.SITE_ID, maxDate)
+                        .from(SITE_ENTRIES)
+                        .groupBy(SITE_ENTRIES.SITE_ID))
+                .as("recentlyUpdated");
 
-    Table<Record4<
-                    Integer, // Site ID
-                    Boolean, // Tree Present
-                    String, // Common Name
-                    Date // Planting Date
-                >> newEntries = table(this.db
-            .select(SITE_ENTRIES.SITE_ID,
-                    SITE_ENTRIES.TREE_PRESENT,
-                    SITE_ENTRIES.COMMON_NAME,
-                    SITE_ENTRIES.PLANTING_DATE)
-            .from(SITE_ENTRIES)
-            .join(recentlyUpdated)
-            .on(SITE_ENTRIES.SITE_ID.eq(recentlyUpdated.field(SITE_ENTRIES.SITE_ID)))
-            .and(SITE_ENTRIES.UPDATED_AT.eq(recentlyUpdated.field(maxDate))
-            )).as("newEntries");
+    Table<
+            Record4<
+                Integer, // Site ID
+                Boolean, // Tree Present
+                String, // Common Name
+                Date // Planting Date
+            >>
+        newEntries =
+            table(
+                    this.db
+                        .select(
+                            SITE_ENTRIES.SITE_ID,
+                            SITE_ENTRIES.TREE_PRESENT,
+                            SITE_ENTRIES.COMMON_NAME,
+                            SITE_ENTRIES.PLANTING_DATE)
+                        .from(SITE_ENTRIES)
+                        .join(recentlyUpdated)
+                        .on(SITE_ENTRIES.SITE_ID.eq(recentlyUpdated.field(SITE_ENTRIES.SITE_ID)))
+                        .and(SITE_ENTRIES.UPDATED_AT.eq(recentlyUpdated.field(maxDate))))
+                .as("newEntries");
     Result<
             Record8<
                 Integer, // Site ID
@@ -220,9 +226,9 @@ public class MapProcessorImpl implements IMapProcessor {
             this.db
                 .select(
                     SITES.ID,
-                        newEntries.field(SITE_ENTRIES.TREE_PRESENT),
-                        newEntries.field(SITE_ENTRIES.COMMON_NAME),
-                        newEntries.field(SITE_ENTRIES.PLANTING_DATE),
+                    newEntries.field(SITE_ENTRIES.TREE_PRESENT),
+                    newEntries.field(SITE_ENTRIES.COMMON_NAME),
+                    newEntries.field(SITE_ENTRIES.PLANTING_DATE),
                     ADOPTED_SITES.USER_ID,
                     SITES.ADDRESS,
                     SITES.LAT,

--- a/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
@@ -177,7 +177,7 @@ public class MapProcessorImpl implements IMapProcessor {
       return SiteGeoResponseCache.getResponse();
     }
 
-    Field<Timestamp> maxDate = max(SITE_ENTRIES.UPDATED_AT).as("MaxDate");
+    Field<Timestamp> maxDate = max(SITE_ENTRIES.UPDATED_AT).as("maxDate");
 
     Table<
             Record2<


### PR DESCRIPTION
Edited the map site query in order to prevent repeating sites from appearing on the map.

Instead of checking if a timestamp is in a subquery, the query uses a series of joins.

The latency for the longest request is slightly longer than before but the mean latency is lower.

![latency](https://user-images.githubusercontent.com/19194912/125123657-eed3c580-e0c4-11eb-8b28-679b71f11896.PNG)

Here is an example of the old output on the frontend

![image](https://user-images.githubusercontent.com/19194912/125125965-63f4ca00-e0c8-11eb-8a99-b355110c9b14.png)

And the same spot with the new query

![no-overlap](https://user-images.githubusercontent.com/19194912/125126068-8e468780-e0c8-11eb-84e4-58e804d213c3.PNG)

