### PR TITLE
updated site import to account for neighborhoods

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/imports/SiteImport.java
+++ b/api/src/main/java/com/codeforcommunity/dto/imports/SiteImport.java
@@ -18,6 +18,7 @@ public class SiteImport extends ApiDto {
   private String city;
   private String zip;
   private String address;
+  private Integer neighborhoodId;
 
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy")
   private Timestamp deletedAt;
@@ -79,6 +80,7 @@ public class SiteImport extends ApiDto {
       String city,
       String zip,
       String address,
+      Integer neighborhoodId,
       Timestamp deletedAt,
       Integer siteId,
       Integer userId,
@@ -132,6 +134,7 @@ public class SiteImport extends ApiDto {
     this.city = city;
     this.zip = zip;
     this.address = address;
+    this.neighborhoodId = neighborhoodId;
     this.deletedAt = deletedAt;
     this.siteId = siteId;
     this.userId = userId;
@@ -229,6 +232,14 @@ public class SiteImport extends ApiDto {
 
   public void setAddress(String address) {
     this.address = address;
+  }
+
+  public Integer getNeighborhoodId() {
+    return neighborhoodId;
+  }
+
+  public void setNeighborhoodId(Integer neighborhoodId) {
+    this.neighborhoodId = neighborhoodId;
   }
 
   public Timestamp getDeletedAt() {

--- a/api/src/main/java/com/codeforcommunity/dto/site/AddSiteRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/AddSiteRequest.java
@@ -11,6 +11,7 @@ public class AddSiteRequest extends UpdateSiteRequest {
   private String city;
   private String zip;
   private String address;
+  private Integer neighborhoodId;
 
   public AddSiteRequest(
       Boolean treePresent,
@@ -56,7 +57,8 @@ public class AddSiteRequest extends UpdateSiteRequest {
       BigDecimal lng,
       String city,
       String zip,
-      String address) {
+      String address,
+      Integer neighborhoodId) {
     super(
         treePresent,
         status,
@@ -102,6 +104,7 @@ public class AddSiteRequest extends UpdateSiteRequest {
     this.city = city;
     this.zip = zip;
     this.address = address;
+    this.neighborhoodId = neighborhoodId;
   }
 
   public AddSiteRequest() {
@@ -156,6 +159,14 @@ public class AddSiteRequest extends UpdateSiteRequest {
     this.address = address;
   }
 
+  public Integer getNeighborhoodId() {
+    return neighborhoodId;
+  }
+
+  public void setNeighborhoodId(Integer neighborhoodId) {
+    this.neighborhoodId = neighborhoodId;
+  }
+
   @Override
   public List<String> validateFields(String fieldPrefix) throws HandledException {
     String fieldName = fieldPrefix + "add_site_request.";
@@ -178,6 +189,9 @@ public class AddSiteRequest extends UpdateSiteRequest {
     }
     if (address == null) {
       fields.add(fieldName + "address");
+    }
+    if (neighborhoodId == null) {
+      fields.add(fieldName + "neighborhood_id");
     }
 
     return fields;

--- a/persist/src/main/resources/db/migration/V3_7__SiteSpeciesCharLength.sql
+++ b/persist/src/main/resources/db/migration/V3_7__SiteSpeciesCharLength.sql
@@ -1,0 +1,2 @@
+ALTER TABLE site_entries
+    ALTER COLUMN species TYPE VARCHAR(50);

--- a/service/src/main/java/com/codeforcommunity/processor/ImportProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ImportProcessorImpl.java
@@ -2,6 +2,7 @@ package com.codeforcommunity.processor;
 
 import static org.jooq.generated.Tables.BLOCKS;
 import static org.jooq.generated.Tables.ENTRY_USERNAMES;
+import static org.jooq.generated.Tables.NEIGHBORHOODS;
 import static org.jooq.generated.Tables.TEAMS;
 import static org.jooq.generated.Tables.USERS;
 
@@ -172,6 +173,15 @@ public class ImportProcessorImpl implements IImportProcessor {
                 throw new ResourceDoesNotExistException(siteImport.getBlockId(), "block");
               }
 
+              if (siteImport.getNeighborhoodId() != null
+                  && !db.fetchExists(
+                      db.selectFrom(
+                          NEIGHBORHOODS.where(
+                              NEIGHBORHOODS.ID.eq(siteImport.getNeighborhoodId()))))) {
+                throw new ResourceDoesNotExistException(
+                    siteImport.getNeighborhoodId(), "neighborhood");
+              }
+
               // Set all values for the site record
               site.setId(siteImport.getSiteId());
               site.setBlockId(siteImport.getBlockId());
@@ -180,6 +190,7 @@ public class ImportProcessorImpl implements IImportProcessor {
               site.setCity(siteImport.getCity());
               site.setZip(siteImport.getZip());
               site.setAddress(siteImport.getAddress());
+              site.setNeighborhoodId(siteImport.getNeighborhoodId());
               if (siteImport.getDeletedAt() != null) {
                 site.setDeletedAt(siteImport.getDeletedAt());
               }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -122,6 +122,7 @@ public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
     sitesRecord.setCity(addSiteRequest.getCity());
     sitesRecord.setZip(addSiteRequest.getZip());
     sitesRecord.setAddress(addSiteRequest.getAddress());
+    sitesRecord.setNeighborhoodId(addSiteRequest.getNeighborhoodId());
 
     sitesRecord.store();
 


### PR DESCRIPTION
https://app.clickup.com/t/1jt6z9c

Recently made changes to the backend script and production database that add neighborhood IDs to the site table. Updating the site import script to ensure that there is not a discrepancy between the data in production and the data on people's local databases.

Changes include:

- Adding neighborhood_id to the import script
- Updated the site.json with all of the information currently in production
- Modified the length of the species column to account for values with length >30 (production already had this change but it was not in a migration script)
- Updated add site route to include neighborhood_id