### PR TITLE
Add canopy coverage to neighborhood table and map route

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/map/NeighborhoodFeatureProperties.java
+++ b/api/src/main/java/com/codeforcommunity/dto/map/NeighborhoodFeatureProperties.java
@@ -6,6 +6,7 @@ public class NeighborhoodFeatureProperties {
   private final Integer neighborhood_id;
   private final String name;
   private final Integer completion_perc;
+  private final Double canopy_coverage;
   private final BigDecimal lat;
   private final BigDecimal lng;
 
@@ -13,11 +14,13 @@ public class NeighborhoodFeatureProperties {
       Integer neighborhood_id,
       String name,
       Integer completion_perc,
+      Double canopy_coverage,
       BigDecimal lat,
       BigDecimal lng) {
     this.neighborhood_id = neighborhood_id;
     this.name = name;
     this.completion_perc = completion_perc;
+    this.canopy_coverage = canopy_coverage;
     this.lat = lat;
     this.lng = lng;
   }
@@ -32,6 +35,10 @@ public class NeighborhoodFeatureProperties {
 
   public Integer getCompletion_perc() {
     return completion_perc;
+  }
+
+  public Double getCanopy_coverage() {
+    return canopy_coverage;
   }
 
   public BigDecimal getLat() {

--- a/persist/src/main/resources/db/migration/V3_8__AddCanopyCoverage.sql
+++ b/persist/src/main/resources/db/migration/V3_8__AddCanopyCoverage.sql
@@ -1,0 +1,1 @@
+ALTER TABLE neighborhoods ADD COLUMN canopy_coverage DOUBLE PRECISION DEFAULT NULL;

--- a/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
@@ -116,6 +116,7 @@ public class MapProcessorImpl implements IMapProcessor {
             neighborhoodsRecord.getId(),
             neighborhoodsRecord.getNeighborhoodName(),
             neighborhoodCompletionPercentage,
+            neighborhoodsRecord.getCanopyCoverage(),
             neighborhoodsRecord.getLat(),
             neighborhoodsRecord.getLng());
     try {


### PR DESCRIPTION
Added `canopy_coverage` to the neighborhoods table and added this as a feature when getting the neighborhoods to display on the map. Will populate this table with data from published reports rather than calculating it based on our data.

https://app.clickup.com/t/1dk41q1