### PR TITLE
Wt.add sites

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -2,6 +2,7 @@ package com.codeforcommunity.api;
 
 import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dto.site.AddSiteRequest;
+import com.codeforcommunity.dto.site.AddSitesRequest;
 import com.codeforcommunity.dto.site.AdoptedSitesResponse;
 import com.codeforcommunity.dto.site.EditSiteRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
@@ -33,6 +34,9 @@ public interface IProtectedSiteProcessor {
 
   /** Edits features of the site */
   void editSite(JWTData userData, int siteId, EditSiteRequest editSiteRequest);
+
+  /** Creates new sites with entries for each item in the list */
+  void addSites(JWTData userData, AddSitesRequest addSitesRequest);
 
   /** Removes the site */
   void deleteSite(JWTData userData, int siteId);

--- a/api/src/main/java/com/codeforcommunity/dto/site/AddSiteRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/AddSiteRequest.java
@@ -172,9 +172,6 @@ public class AddSiteRequest extends UpdateSiteRequest {
     String fieldName = fieldPrefix + "add_site_request.";
     List<String> fields = super.validateFields("");
 
-    if (blockId == null) {
-      fields.add(fieldName + "block_id");
-    }
     if (lat == null) {
       fields.add(fieldName + "lat");
     }

--- a/api/src/main/java/com/codeforcommunity/dto/site/AddSitesRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/AddSitesRequest.java
@@ -1,0 +1,38 @@
+package com.codeforcommunity.dto.site;
+
+import com.codeforcommunity.dto.ApiDto;
+import com.codeforcommunity.exceptions.HandledException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AddSitesRequest extends ApiDto {
+  private List<AddSiteRequest> sites;
+
+  public AddSitesRequest(List<AddSiteRequest> sites) {
+    this.sites = sites;
+  }
+
+  private AddSitesRequest() {}
+
+  public List<AddSiteRequest> getSites() {
+    return sites;
+  }
+
+  public void setSites(List<AddSiteRequest> sites) {
+    this.sites = sites;
+  }
+
+  @Override
+  public List<String> validateFields(String fieldPrefix) throws HandledException {
+    String newFieldPrefix = fieldPrefix + "addSitesRequest.";
+
+    if (sites == null) {
+      return Collections.singletonList(newFieldPrefix + "sites");
+    }
+
+    return sites.stream()
+        .flatMap(ni -> ni.validateFields(newFieldPrefix).stream())
+        .collect(Collectors.toList());
+  }
+}

--- a/api/src/main/java/com/codeforcommunity/dto/site/UpdateSiteRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/UpdateSiteRequest.java
@@ -272,7 +272,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isStakesWithoutWires() {
-    return falseIfNull(isStakesWithoutWires());
+    return falseIfNull(stakesWithoutWires);
   }
 
   public void setStakesWithoutWires(Boolean stakesWithoutWires) {
@@ -304,7 +304,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isBagFilled() {
-    return falseIfNull(isBagFilled());
+    return falseIfNull(bagFilled);
   }
 
   public void setBagFilled(Boolean bagFilled) {
@@ -312,7 +312,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isTape() {
-    return falseIfNull(isTape());
+    return falseIfNull(tape);
   }
 
   public void setTape(Boolean tape) {
@@ -320,7 +320,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isSuckerGrowth() {
-    return falseIfNull(isSuckerGrowth());
+    return falseIfNull(suckerGrowth);
   }
 
   public void setSuckerGrowth(Boolean suckerGrowth) {

--- a/api/src/main/java/com/codeforcommunity/dto/site/UpdateSiteRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/UpdateSiteRequest.java
@@ -4,6 +4,7 @@ import com.codeforcommunity.dto.ApiDto;
 import com.codeforcommunity.exceptions.HandledException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class UpdateSiteRequest extends ApiDto {
   private Boolean treePresent;
@@ -127,7 +128,7 @@ public class UpdateSiteRequest extends ApiDto {
   public UpdateSiteRequest() {}
 
   public Boolean isTreePresent() {
-    return treePresent;
+    return falseIfNull(treePresent);
   }
 
   public void setTreePresent(Boolean treePresent) {
@@ -191,7 +192,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isMultistem() {
-    return multistem;
+    return falseIfNull(multistem);
   }
 
   public void setMultistem(Boolean multistem) {
@@ -223,7 +224,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isDiscoloring() {
-    return discoloring;
+    return falseIfNull(discoloring);
   }
 
   public void setDiscoloring(Boolean discoloring) {
@@ -231,7 +232,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isLeaning() {
-    return leaning;
+    return falseIfNull(leaning);
   }
 
   public void setLeaning(Boolean leaning) {
@@ -239,7 +240,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isConstrictingGrate() {
-    return constrictingGrate;
+    return falseIfNull(constrictingGrate);
   }
 
   public void setConstrictingGrate(Boolean constrictingGrate) {
@@ -247,7 +248,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isWounds() {
-    return wounds;
+    return falseIfNull(wounds);
   }
 
   public void setWounds(Boolean wounds) {
@@ -255,7 +256,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isPooling() {
-    return pooling;
+    return falseIfNull(pooling);
   }
 
   public void setPooling(Boolean pooling) {
@@ -263,7 +264,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isStakesWithWires() {
-    return stakesWithWires;
+    return falseIfNull(stakesWithWires);
   }
 
   public void setStakesWithWires(Boolean stakesWithWires) {
@@ -271,7 +272,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isStakesWithoutWires() {
-    return stakesWithoutWires;
+    return falseIfNull(isStakesWithoutWires());
   }
 
   public void setStakesWithoutWires(Boolean stakesWithoutWires) {
@@ -279,7 +280,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isLight() {
-    return light;
+    return falseIfNull(light);
   }
 
   public void setLight(Boolean light) {
@@ -287,7 +288,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isBicycle() {
-    return bicycle;
+    return falseIfNull(bicycle);
   }
 
   public void setBicycle(Boolean bicycle) {
@@ -295,7 +296,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isBagEmpty() {
-    return bagEmpty;
+    return falseIfNull(bagEmpty);
   }
 
   public void setBagEmpty(Boolean bagEmpty) {
@@ -303,7 +304,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isBagFilled() {
-    return bagFilled;
+    return falseIfNull(isBagFilled());
   }
 
   public void setBagFilled(Boolean bagFilled) {
@@ -311,7 +312,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isTape() {
-    return tape;
+    return falseIfNull(isTape());
   }
 
   public void setTape(Boolean tape) {
@@ -319,7 +320,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isSuckerGrowth() {
-    return suckerGrowth;
+    return falseIfNull(isSuckerGrowth());
   }
 
   public void setSuckerGrowth(Boolean suckerGrowth) {
@@ -367,7 +368,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isRaisedBed() {
-    return raisedBed;
+    return falseIfNull(raisedBed);
   }
 
   public void setRaisedBed(Boolean raisedBed) {
@@ -375,7 +376,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isFence() {
-    return fence;
+    return falseIfNull(fence);
   }
 
   public void setFence(Boolean fence) {
@@ -383,7 +384,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isTrash() {
-    return trash;
+    return falseIfNull(trash);
   }
 
   public void setTrash(Boolean trash) {
@@ -391,7 +392,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isWires() {
-    return wires;
+    return falseIfNull(wires);
   }
 
   public void setWires(Boolean wires) {
@@ -399,7 +400,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isGrate() {
-    return grate;
+    return falseIfNull(grate);
   }
 
   public void setGrate(Boolean grate) {
@@ -407,7 +408,7 @@ public class UpdateSiteRequest extends ApiDto {
   }
 
   public Boolean isStump() {
-    return stump;
+    return falseIfNull(stump);
   }
 
   public void setStump(Boolean stump) {
@@ -428,6 +429,10 @@ public class UpdateSiteRequest extends ApiDto {
 
   public void setSiteNotes(String siteNotes) {
     this.siteNotes = siteNotes;
+  }
+
+  private boolean falseIfNull(Boolean bool) {
+    return Optional.ofNullable(bool).orElse(false);
   }
 
   @Override

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -5,6 +5,7 @@ import static com.codeforcommunity.rest.ApiRouter.end;
 import com.codeforcommunity.api.IProtectedSiteProcessor;
 import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dto.site.AddSiteRequest;
+import com.codeforcommunity.dto.site.AddSitesRequest;
 import com.codeforcommunity.dto.site.AdoptedSitesResponse;
 import com.codeforcommunity.dto.site.EditSiteRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
@@ -39,6 +40,7 @@ public class ProtectedSiteRouter implements IRouter {
     registerUpdateSite(router);
     registerDeleteSite(router);
     registerEditSite(router);
+    registerAddSites(router);
     registerDeleteStewardship(router);
 
     return router;
@@ -144,6 +146,21 @@ public class ProtectedSiteRouter implements IRouter {
     AddSiteRequest addSiteRequest = RestFunctions.getJsonBodyAsClass(ctx, AddSiteRequest.class);
 
     processor.addSite(userData, addSiteRequest);
+
+    end(ctx.response(), 200);
+  }
+
+  private void registerAddSites(Router router) {
+    Route addSiteRoute = router.post("/add_sites");
+    addSiteRoute.handler(this::handleAddSitesRoute);
+  }
+
+  private void handleAddSitesRoute(RoutingContext ctx) {
+    JWTData userData = ctx.get("jwt_data");
+
+    AddSitesRequest addSitesRequest = RestFunctions.getJsonBodyAsClass(ctx, AddSitesRequest.class);
+
+    processor.addSites(userData, addSitesRequest);
 
     end(ctx.response(), 200);
   }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -7,6 +7,7 @@ import static org.jooq.generated.Tables.SITES;
 import static org.jooq.generated.Tables.SITE_ENTRIES;
 import static org.jooq.generated.Tables.STEWARDSHIP;
 import static org.jooq.generated.Tables.USERS;
+import static org.jooq.impl.DSL.max;
 
 import com.codeforcommunity.api.IProtectedSiteProcessor;
 import com.codeforcommunity.auth.JWTData;
@@ -157,6 +158,9 @@ public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
 
     SitesRecord sitesRecord = db.newRecord(SITES);
 
+    int newId = db.select(max(SITES.ID)).from(SITES).fetchOne(0, Integer.class) + 1;
+
+    sitesRecord.setId(newId);
     sitesRecord.setBlockId(addSiteRequest.getBlockId());
     sitesRecord.setLat(addSiteRequest.getLat());
     sitesRecord.setLng(addSiteRequest.getLng());

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -6,7 +6,6 @@ import static org.jooq.generated.Tables.NEIGHBORHOODS;
 import static org.jooq.generated.Tables.SITES;
 import static org.jooq.generated.Tables.SITE_ENTRIES;
 import static org.jooq.generated.Tables.STEWARDSHIP;
-import static org.jooq.generated.Tables.USERS;
 import static org.jooq.impl.DSL.max;
 
 import com.codeforcommunity.api.IProtectedSiteProcessor;
@@ -293,9 +292,7 @@ public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
 
   @Override
   public void addSites(JWTData userData, AddSitesRequest addSitesRequest) {
-    if ((!db.fetchExists(db.selectFrom(USERS).where(USERS.ID.eq(userData.getUserId()))))) {
-      throw new UserDoesNotExistException(userData.getUserId());
-    }
+
     isAdminCheck(userData.getPrivilegeLevel());
 
     addSitesRequest


### PR DESCRIPTION
https://app.clickup.com/t/1dk48g9

Creates a route where admins can create more than one site at a time. Uses logic already defined to add individual sites. 

Also modified some of the constraints on add site and update site such as defaulting boolean values to false and making block_id an optional field.

Originally attempted to handle csv parsing and processing on the server, however given the small size of the the expected csvs and familiarity with csv parsing in Typescript, decided to handle csv processing on the frontend.