### PR TITLE
Add canopy coverage to neighborhoods import route

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/imports/NeighborhoodImport.java
+++ b/api/src/main/java/com/codeforcommunity/dto/imports/NeighborhoodImport.java
@@ -13,6 +13,7 @@ public class NeighborhoodImport extends ApiDto {
   private BigDecimal lat;
   private BigDecimal lng;
   private String geometry;
+  private Double canopyCoverage;
 
   public NeighborhoodImport(
       Integer neighborhoodId,
@@ -20,13 +21,15 @@ public class NeighborhoodImport extends ApiDto {
       BigDecimal sqmiles,
       BigDecimal lat,
       BigDecimal lng,
-      String geometry) {
+      String geometry,
+      Double canopyCoverage) {
     this.neighborhoodId = neighborhoodId;
     this.name = name;
     this.sqmiles = sqmiles;
     this.lat = lat;
     this.lng = lng;
     this.geometry = geometry;
+    this.canopyCoverage = canopyCoverage;
   }
 
   private NeighborhoodImport() {}
@@ -79,6 +82,14 @@ public class NeighborhoodImport extends ApiDto {
     this.geometry = geometry;
   }
 
+  public Double getCanopyCoverage() {
+    return canopyCoverage;
+  }
+
+  public void setCanopyCoverage(Double canopyCoverage) {
+    this.canopyCoverage = canopyCoverage;
+  }
+
   @Override
   public List<String> validateFields(String fieldPrefix) throws HandledException {
     String fieldName = fieldPrefix + "neighborhood.";
@@ -101,6 +112,9 @@ public class NeighborhoodImport extends ApiDto {
     }
     if (isEmpty(geometry)) {
       fields.add(fieldName + "geometry");
+    }
+    if (canopyCoverage == null || canopyCoverage < 0 || canopyCoverage > 1) {
+      fields.add(fieldName + "canopyCoverage");
     }
 
     return fields;

--- a/service/src/main/java/com/codeforcommunity/processor/ImportProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ImportProcessorImpl.java
@@ -76,6 +76,7 @@ public class ImportProcessorImpl implements IImportProcessor {
       neighborhood.setLat(neighborhoodImport.getLat());
       neighborhood.setLng(neighborhoodImport.getLng());
       neighborhood.setGeometry(neighborhoodImport.getGeometry());
+      neighborhood.setCanopyCoverage(neighborhoodImport.getCanopyCoverage());
 
       neighborhood.store();
     }


### PR DESCRIPTION
Changed the neighborhood import route and import processor to also import canopy coverage data when importing neighborhoods.

Clickup ticket: https://app.clickup.com/t/1q872u4