### PR TITLE
added check to ensure user has adopted a particular site for recording stewardship

### DIFF
--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -19,7 +19,6 @@ import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import com.codeforcommunity.enums.PrivilegeLevel;
 import com.codeforcommunity.exceptions.AuthException;
 import com.codeforcommunity.exceptions.ResourceDoesNotExistException;
-import com.codeforcommunity.exceptions.UserDoesNotExistException;
 import com.codeforcommunity.exceptions.WrongAdoptionStatusException;
 import java.sql.Date;
 import java.sql.Timestamp;
@@ -134,6 +133,9 @@ public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
   public void recordStewardship(
       JWTData userData, int siteId, RecordStewardshipRequest recordStewardshipRequest) {
     checkSiteExists(siteId);
+    if (!isAlreadyAdoptedByUser(userData.getUserId(), siteId)) {
+      throw new WrongAdoptionStatusException(false);
+    }
 
     StewardshipRecord record = db.newRecord(STEWARDSHIP);
     record.setUserId(userData.getUserId());


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/1dk490u

Ensures that the user has adopted the given site before recording a stewardship activity. Returns a 400 exception if they are not the adopter.

The check if user has adopted site method and exception already existed, just added them to the record stewardship method