### PR TITLE
Fixed the GetSiteResponse object

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/site/GetSiteResponse.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/GetSiteResponse.java
@@ -11,7 +11,7 @@ public class GetSiteResponse {
   private final String city;
   private final String zip;
   private final String address;
-  private final String neighborhood;
+  private final Integer neighborhoodId;
   private final List<SiteEntry> entries;
 
   public GetSiteResponse(
@@ -22,7 +22,7 @@ public class GetSiteResponse {
       String city,
       String zip,
       String address,
-      String neighborhood,
+      Integer neighborhoodId,
       List<SiteEntry> entries) {
     this.siteId = siteId;
     this.blockId = blockId;
@@ -32,7 +32,7 @@ public class GetSiteResponse {
     this.zip = zip;
     this.address = address;
     this.entries = entries;
-    this.neighborhood = neighborhood;
+    this.neighborhoodId = neighborhoodId;
   }
 
   public Integer getSiteId() {
@@ -63,8 +63,8 @@ public class GetSiteResponse {
     return address;
   }
 
-  public String getNeighborhood() {
-    return neighborhood;
+  public Integer getNeighborhood() {
+    return neighborhoodId;
   }
 
   public List<SiteEntry> getEntries() {

--- a/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
@@ -134,18 +134,6 @@ public class SiteProcessorImpl implements ISiteProcessor {
       throw new ResourceDoesNotExistException(siteId, "site");
     }
 
-    String neighborhood;
-
-    if (sitesRecord.getNeighborhoodId() == null) {
-      neighborhood = "Unknown Neighborhood";
-    } else {
-      neighborhood =
-          db.selectFrom(NEIGHBORHOODS)
-              .where(NEIGHBORHOODS.ID.eq(sitesRecord.getNeighborhoodId()))
-              .fetchOne()
-              .getNeighborhoodName();
-    }
-
     return new GetSiteResponse(
         sitesRecord.getId(),
         sitesRecord.getBlockId(),
@@ -154,7 +142,7 @@ public class SiteProcessorImpl implements ISiteProcessor {
         sitesRecord.getCity(),
         sitesRecord.getZip(),
         sitesRecord.getAddress(),
-        neighborhood,
+        sitesRecord.getNeighborhoodId(),
         getSiteEntries(siteId));
   }
 


### PR DESCRIPTION
Fixed the GetSiteResponse object to use a neighborhood's ID rather than its name, and changed SiteProcessorImpl to pass the correct value to the GetSiteResponse constructor. @jhylisa666 