### PR TITLE
Jh.lj Force Unadopt Route for Admins

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -19,7 +19,7 @@ public interface IProtectedSiteProcessor {
   /** Removes the record in the adopted sites table linking the user and the site */
   void unadoptSite(JWTData userData, int siteId);
 
-  /** Removes the record in the adopted sites table the site to its current adopter */
+  /** Removes the record in the adopted sites table linking the site to its current adopter */
   void forceUnadoptSite(JWTData userData, int siteId);
 
   /** Get users adopted sites */

--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -19,6 +19,9 @@ public interface IProtectedSiteProcessor {
   /** Removes the record in the adopted sites table linking the user and the site */
   void unadoptSite(JWTData userData, int siteId);
 
+  /** Removes the record in the adopted sites table the site to its current adopter */
+  void forceUnadoptSite(JWTData userData, int siteId);
+
   /** Get users adopted sites */
   AdoptedSitesResponse getAdoptedSites(JWTData userData);
 

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -34,6 +34,7 @@ public class ProtectedSiteRouter implements IRouter {
 
     registerAdoptSite(router);
     registerUnadoptSite(router);
+    registerForceUnadoptSite(router);
     registerGetAdoptedSitesRoute(router);
     registerRecordStewardship(router);
     registerAddSite(router);
@@ -70,6 +71,20 @@ public class ProtectedSiteRouter implements IRouter {
     int siteId = RestFunctions.getRequestParameterAsInt(ctx.request(), "site_id");
 
     processor.unadoptSite(userData, siteId);
+
+    end(ctx.response(), 200);
+  }
+
+  private void registerForceUnadoptSite(Router router) {
+    Route forceUnadoptSiteRoute = router.post("/:site_id/force_unadopt");
+    forceUnadoptSiteRoute.handler(this::handleForceUnadoptSiteRoute);
+  }
+
+  private void handleForceUnadoptSiteRoute(RoutingContext ctx) {
+    JWTData userData = ctx.get("jwt_data");
+    int siteId = RestFunctions.getRequestParameterAsInt(ctx.request(), "site_id");
+
+    processor.forceUnadoptSite(userData, siteId);
 
     end(ctx.response(), 200);
   }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -131,12 +131,12 @@ public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
       throw new WrongAdoptionStatusException(false); // wrong error?
     }
 
-    AdoptedSitesRecord result = db.selectFrom(ADOPTED_SITES)
+    AdoptedSitesRecord adoptedSite = db.selectFrom(ADOPTED_SITES)
             .where(ADOPTED_SITES.SITE_ID.eq(siteId))
             .fetchInto(AdoptedSitesRecord.class)
             .get(0);
 
-    Integer adopterId = result.getUserId();
+    Integer adopterId = adoptedSite.getUserId();
 
     UsersRecord adopter = db.selectFrom(USERS)
             .where(USERS.ID.eq(adopterId))

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -136,7 +136,7 @@ public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
     isAdminCheck(userData.getPrivilegeLevel());
     checkSiteExists(siteId);
     if (!isAlreadyAdopted(siteId)) {
-      throw new WrongAdoptionStatusException(false); // wrong error?
+      throw new WrongAdoptionStatusException(false);
     }
 
     AdoptedSitesRecord adoptedSite = db.selectFrom(ADOPTED_SITES)
@@ -150,7 +150,7 @@ public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
             .where(USERS.ID.eq(adopterId))
             .fetchOne();
 
-    if(isAdmin(adopter.getPrivilegeLevel()) && !(userData.getPrivilegeLevel() == (PrivilegeLevel.SUPER_ADMIN))) {
+    if(isAdmin(adopter.getPrivilegeLevel()) && !(userData.getPrivilegeLevel().equals(PrivilegeLevel.SUPER_ADMIN))) {
       throw new AuthException("User does not have the required privilege level.");
     }
 

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -120,6 +120,19 @@ public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
   }
 
   @Override
+  public void forceUnadoptSite(JWTData userData, int siteId) {
+    isAdminCheck(userData.getPrivilegeLevel());
+    checkSiteExists(siteId);
+    if (!isAlreadyAdopted(siteId)) {
+      throw new WrongAdoptionStatusException(false); // wrong error?
+    }
+
+    db.deleteFrom(ADOPTED_SITES)
+            .where(ADOPTED_SITES.SITE_ID.eq(siteId))
+            .execute();
+  }
+
+  @Override
   public AdoptedSitesResponse getAdoptedSites(JWTData userData) {
     List<Integer> favoriteSites =
         db.selectFrom(ADOPTED_SITES)

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -1,6 +1,12 @@
 package com.codeforcommunity.processor;
 
-import static org.jooq.generated.Tables.*;
+import static org.jooq.generated.Tables.ADOPTED_SITES;
+import static org.jooq.generated.Tables.BLOCKS;
+import static org.jooq.generated.Tables.NEIGHBORHOODS;
+import static org.jooq.generated.Tables.SITES;
+import static org.jooq.generated.Tables.USERS;
+import static org.jooq.generated.Tables.SITE_ENTRIES;
+import static org.jooq.generated.Tables.STEWARDSHIP;
 import static org.jooq.impl.DSL.max;
 
 import com.codeforcommunity.api.IProtectedSiteProcessor;
@@ -19,9 +25,11 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.List;
 import org.jooq.DSLContext;
-import org.jooq.Record1;
-import org.jooq.Result;
-import org.jooq.generated.tables.records.*;
+import org.jooq.generated.tables.records.AdoptedSitesRecord;
+import org.jooq.generated.tables.records.SiteEntriesRecord;
+import org.jooq.generated.tables.records.SitesRecord;
+import org.jooq.generated.tables.records.UsersRecord;
+import org.jooq.generated.tables.records.StewardshipRecord;
 
 public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
 


### PR DESCRIPTION
@jhylisa666 and I worked on a new route that allows admins to force unadopt the sites of standard users and allows super admins to force unadopt the sites of standard users, admins, and other super admins.

In the course of modifying the ProtectedSiteProcessor, we also added a new utility method `isAdmin(PrivilegeLevel)` which returns a boolean indicating whether a user with the given privilege level is an admin or super admin.

Route is accessible via:
`POST api/v1/protected/sites/:site_id/force_unadopt`