### PR TITLE
Route to name most recent site entry for an adopted site

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -48,6 +48,9 @@ public interface IProtectedSiteProcessor {
   /** Removes the given stewardship activity */
   void deleteStewardship(JWTData userData, int activityId);
 
-  /** Removes the record in the adopted sites table linking the site to its current adopter */
+  /**
+   * Renames the latest site entry of the site with the given siteId
+   * using the new name specified in the nameSiteEntryRequest
+   */
   void nameSiteEntry(JWTData userData, int siteId, NameSiteEntryRequest nameSiteEntryRequest);
 }

--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -5,6 +5,7 @@ import com.codeforcommunity.dto.site.AddSiteRequest;
 import com.codeforcommunity.dto.site.AddSitesRequest;
 import com.codeforcommunity.dto.site.AdoptedSitesResponse;
 import com.codeforcommunity.dto.site.EditSiteRequest;
+import com.codeforcommunity.dto.site.NameSiteEntryRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import java.sql.Date;
@@ -46,4 +47,7 @@ public interface IProtectedSiteProcessor {
 
   /** Removes the given stewardship activity */
   void deleteStewardship(JWTData userData, int activityId);
+
+  /** Removes the record in the adopted sites table linking the site to its current adopter */
+  void nameSiteEntry(JWTData userData, int siteId, NameSiteEntryRequest nameSiteEntryRequest);
 }

--- a/api/src/main/java/com/codeforcommunity/dto/site/NameSiteEntryRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/NameSiteEntryRequest.java
@@ -17,7 +17,6 @@ public class NameSiteEntryRequest extends ApiDto {
     this.name = name;
   }
 
-
   @Override
   public List<String> validateFields(String fieldPrefix) throws HandledException {
     String fieldName = fieldPrefix + "new_site_entry_name_request.";

--- a/api/src/main/java/com/codeforcommunity/dto/site/NameSiteEntryRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/NameSiteEntryRequest.java
@@ -1,0 +1,31 @@
+package com.codeforcommunity.dto.site;
+
+import com.codeforcommunity.dto.ApiDto;
+import com.codeforcommunity.exceptions.HandledException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NameSiteEntryRequest extends ApiDto {
+  private String name;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+
+  @Override
+  public List<String> validateFields(String fieldPrefix) throws HandledException {
+    String fieldName = fieldPrefix + "new_site_entry_name_request.";
+    List<String> fields = new ArrayList<>();
+
+    if (name == null || name.isEmpty() || name.length() > 60) {
+      fields.add(fieldName + "site_entry_name");
+    }
+    return fields;
+  }
+}

--- a/api/src/main/java/com/codeforcommunity/exceptions/LinkedResourceDoesNotExistException.java
+++ b/api/src/main/java/com/codeforcommunity/exceptions/LinkedResourceDoesNotExistException.java
@@ -1,0 +1,55 @@
+package com.codeforcommunity.exceptions;
+
+import com.codeforcommunity.rest.FailureHandler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Resource does not exist exception for resources
+ * which combine two other resources,
+ * and which have no meaningful id on their own.
+ */
+public class LinkedResourceDoesNotExistException extends HandledException {
+
+  private final int resource1Id;
+  private final int resource2Id;
+  private final String resource1Type;
+  private final String resource2Type;
+  private final String linkedResourceType;
+
+  public LinkedResourceDoesNotExistException(String linkedResourceType,
+                                             int resource1Id,
+                                             String resource1Type,
+                                             int resource2Id,
+                                             String resource2Type) {
+    this.resource1Id = resource1Id;
+    this.resource2Id = resource2Id;
+    this.resource1Type = resource1Type;
+    this.resource2Type = resource2Type;
+    this.linkedResourceType = linkedResourceType;
+  }
+
+  public int getResource1Id() {
+    return this.resource1Id;
+  }
+
+  public int getResource2Id() {
+    return this.resource2Id;
+  }
+
+  public String getResource1Type() {
+    return this.resource1Type;
+  }
+
+  public String getResource2Type() {
+    return this.resource2Type;
+  }
+
+  public String getlinkedResourceType() {
+    return this.linkedResourceType;
+  }
+
+  @Override
+  public void callHandler(FailureHandler handler, RoutingContext ctx) {
+    handler.handleLinkedResourceDoesNotExist(ctx, this);
+  }
+}

--- a/api/src/main/java/com/codeforcommunity/rest/FailureHandler.java
+++ b/api/src/main/java/com/codeforcommunity/rest/FailureHandler.java
@@ -7,6 +7,7 @@ import com.codeforcommunity.exceptions.HandledException;
 import com.codeforcommunity.exceptions.IncorrectBlockStatusException;
 import com.codeforcommunity.exceptions.InvalidSecretKeyException;
 import com.codeforcommunity.exceptions.LeaderCannotLeaveTeamException;
+import com.codeforcommunity.exceptions.LinkedResourceDoesNotExistException;
 import com.codeforcommunity.exceptions.MalformedParameterException;
 import com.codeforcommunity.exceptions.MemberApplicationException;
 import com.codeforcommunity.exceptions.MemberStatusException;
@@ -98,6 +99,17 @@ public class FailureHandler {
   public void handleResourceDoesNotExist(RoutingContext ctx, ResourceDoesNotExistException e) {
     String message =
         String.format("No <%s> with id <%d> exists", e.getResourceType(), e.getResourceId());
+    end(ctx, message, 400);
+  }
+
+  public void handleLinkedResourceDoesNotExist(RoutingContext ctx, LinkedResourceDoesNotExistException e) {
+    String message =
+        String.format("No linked resource <%s> with resource <%s> of id <%d> and resource <%s> of id <%d> exists",
+                      e.getlinkedResourceType(),
+                      e.getResource1Type(),
+                      e.getResource1Id(),
+                      e.getResource2Type(),
+                      e.getResource2Id());
     end(ctx, message, 400);
   }
 

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -8,6 +8,7 @@ import com.codeforcommunity.dto.site.AddSiteRequest;
 import com.codeforcommunity.dto.site.AddSitesRequest;
 import com.codeforcommunity.dto.site.AdoptedSitesResponse;
 import com.codeforcommunity.dto.site.EditSiteRequest;
+import com.codeforcommunity.dto.site.NameSiteEntryRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import com.codeforcommunity.rest.IRouter;
@@ -43,6 +44,7 @@ public class ProtectedSiteRouter implements IRouter {
     registerEditSite(router);
     registerAddSites(router);
     registerDeleteStewardship(router);
+    registerNameSiteEntry(router);
 
     return router;
   }
@@ -206,6 +208,23 @@ public class ProtectedSiteRouter implements IRouter {
     EditSiteRequest editSiteRequest = RestFunctions.getJsonBodyAsClass(ctx, EditSiteRequest.class);
 
     processor.editSite(userData, siteId, editSiteRequest);
+
+    end(ctx.response(), 200);
+  }
+
+  private void registerNameSiteEntry(Router router) {
+    Route nameSiteEntry = router.post("/:site_id/name_entry");
+    nameSiteEntry.handler(this::handleNameSiteEntry);
+  }
+
+  private void handleNameSiteEntry(RoutingContext ctx) {
+    JWTData userData = ctx.get("jwt_data");
+    int siteId = RestFunctions.getRequestParameterAsInt(ctx.request(), "site_id");
+
+    NameSiteEntryRequest nameSiteEntryRequest =
+        RestFunctions.getJsonBodyAsClass(ctx, NameSiteEntryRequest.class);
+
+    processor.nameSiteEntry(userData, siteId, nameSiteEntryRequest);
 
     end(ctx.response(), 200);
   }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -20,6 +20,7 @@ import com.codeforcommunity.dto.site.RecordStewardshipRequest;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import com.codeforcommunity.enums.PrivilegeLevel;
 import com.codeforcommunity.exceptions.AuthException;
+import com.codeforcommunity.exceptions.LinkedResourceDoesNotExistException;
 import com.codeforcommunity.exceptions.ResourceDoesNotExistException;
 import com.codeforcommunity.exceptions.WrongAdoptionStatusException;
 import java.sql.Date;
@@ -391,7 +392,11 @@ public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
         .fetchOne();
 
     if (siteEntry == null) {
-      throw new ResourceDoesNotExistException(siteId, "Site Entry");
+      throw new LinkedResourceDoesNotExistException("Site Entry",
+                                                    userData.getUserId(),
+                                                    "User",
+                                                    siteId,
+                                                    "Site");
     }
 
     siteEntry.setTreeName(nameSiteEntryRequest.getName());

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -26,6 +26,8 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.List;
 import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record1;
 import org.jooq.generated.tables.records.AdoptedSitesRecord;
 import org.jooq.generated.tables.records.SiteEntriesRecord;
 import org.jooq.generated.tables.records.SitesRecord;
@@ -384,7 +386,14 @@ public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
 
     SiteEntriesRecord siteEntry = db.selectFrom(SITE_ENTRIES)
         .where(SITE_ENTRIES.SITE_ID.eq(siteId))
+        .orderBy(SITE_ENTRIES.UPDATED_AT)
+        .limit(1)
         .fetchOne();
+
+    if (siteEntry == null) {
+      throw new ResourceDoesNotExistException(siteId, "Site Entry");
+    }
+
     siteEntry.setTreeName(nameSiteEntryRequest.getName());
     siteEntry.store();
   }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -15,6 +15,7 @@ import com.codeforcommunity.dto.site.AddSiteRequest;
 import com.codeforcommunity.dto.site.AddSitesRequest;
 import com.codeforcommunity.dto.site.AdoptedSitesResponse;
 import com.codeforcommunity.dto.site.EditSiteRequest;
+import com.codeforcommunity.dto.site.NameSiteEntryRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import com.codeforcommunity.enums.PrivilegeLevel;
@@ -373,5 +374,18 @@ public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
     }
 
     db.deleteFrom(STEWARDSHIP).where(STEWARDSHIP.ID.eq(activityId)).execute();
+  }
+
+  public void nameSiteEntry(JWTData userData, int siteId, NameSiteEntryRequest nameSiteEntryRequest) {
+    checkSiteExists(siteId);
+    if (!isAlreadyAdoptedByUser(userData.getUserId(), siteId)) {
+      throw new AuthException("User is not the site's adopter.");
+    }
+
+    SiteEntriesRecord siteEntry = db.selectFrom(SITE_ENTRIES)
+        .where(SITE_ENTRIES.SITE_ID.eq(siteId))
+        .fetchOne();
+    siteEntry.setTreeName(nameSiteEntryRequest.getName());
+    siteEntry.store();
   }
 }


### PR DESCRIPTION
Created a route for renaming the most recent site entry that exists for a given site id. The site must be adopted by the calling user.

Route accessible via:
`POST api/v1/protected/sites/:site_id/name_entry`

Also created a LinkedResourceDoesNotExist exception in order to give more information in the case of a resource not existing that on its own does not have a meaningful id. The exception responds with a `400 BAD REQUEST` status. An example of the error message is shown below:

![Screenshot 2022-03-20 144916](https://user-images.githubusercontent.com/46767048/159178407-8ad7ca1b-9761-4f38-ad8c-645089ed55ee.png)

[ClickUp Ticket](https://app.clickup.com/t/22gq4y3)
