### PR TITLE
Update forgot password email template

### DIFF
--- a/common/src/main/resources/emails/PasswordChangeRequest.html
+++ b/common/src/main/resources/emails/PasswordChangeRequest.html
@@ -1,14 +1,20 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
-
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
-  <!--[if gte mso 9]><xml><o:OfficeDocumentSettings><o:AllowPNG/><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml><![endif]-->
+  <!--[if gte mso 9]>
+  <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+  </xml>
+  <![endif]-->
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width">
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
-  <title></title>
+  <title>Forgot Password Email</title>
   <!--[if !mso]><!-->
   <!--<![endif]-->
   <style type="text/css">
@@ -16,18 +22,20 @@
       margin: 0;
       padding: 0;
     }
-
     table,
     td,
     tr {
       vertical-align: top;
       border-collapse: collapse;
     }
-
     * {
       line-height: inherit;
     }
-
+    .standard-table {
+      width: 100%;
+      border: 0;
+      border-collapse: collapse;
+    }
     a[x-apple-data-detectors=true] {
       color: inherit !important;
       text-decoration: none !important;
@@ -35,181 +43,130 @@
   </style>
   <style type="text/css" id="media-query">
     @media (max-width: 660px) {
-
       .block-grid,
       .col {
         min-width: 320px !important;
         max-width: 100% !important;
         display: block !important;
       }
-
       .block-grid {
         width: 100% !important;
       }
-
       .col {
         width: 100% !important;
       }
-
       .col>div {
         margin: 0 auto;
       }
-
-      img.fullwidth,
-      img.fullwidthOnMobile {
-        max-width: 100% !important;
-      }
-
       .no-stack .col {
         min-width: 0 !important;
         display: table-cell !important;
       }
-
       .no-stack.two-up .col {
         width: 50% !important;
-      }
-
-      .no-stack .col.num4 {
-        width: 33% !important;
-      }
-
-      .no-stack .col.num8 {
-        width: 66% !important;
-      }
-
-      .no-stack .col.num4 {
-        width: 33% !important;
-      }
-
-      .no-stack .col.num3 {
-        width: 25% !important;
-      }
-
-      .no-stack .col.num6 {
-        width: 50% !important;
-      }
-
-      .no-stack .col.num9 {
-        width: 75% !important;
-      }
-
-      .video-block {
-        max-width: none !important;
-      }
-
-      .mobile_hide {
-        min-height: 0px;
-        max-height: 0px;
-        max-width: 0px;
-        display: none;
-        overflow: hidden;
-        font-size: 0px;
-      }
-
-      .desktop_hide {
-        display: block !important;
-        max-height: none !important;
       }
     }
   </style>
 </head>
-
 <body class="clean-body" style="margin: 0; padding: 0; -webkit-text-size-adjust: 100%; background-color: #f8f8f9;">
-<!--[if IE]><div class="ie-browser"><![endif]-->
-<table class="nl-container" style="table-layout: fixed; vertical-align: top; min-width: 320px; Margin: 0 auto; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #f8f8f9; width: 100%;" cellpadding="0" cellspacing="0" role="presentation" width="100%" bgcolor="#f8f8f9" valign="top">
+<!--[if IE]>
+<div class="ie-browser">
+<![endif]-->
+<table class="nl-container" style="table-layout: fixed; vertical-align: top; min-width: 320px; margin: 0 auto; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0; background-color: #f8f8f9; width: 100%;" cellpadding="0" cellspacing="0" role="presentation" width="100%" bgcolor="#f8f8f9" valign="top">
   <tbody>
   <tr style="vertical-align: top;" valign="top">
     <td style="word-break: break-word; vertical-align: top;" valign="top">
-      <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color:#f8f8f9"><![endif]-->
+      <!--[if (mso)|(IE)]>
+      <table style="border-collapse: collapse; border: 0">
+        <tr>
+          <td style="width=100%; background-color:#f8f8f9; text-align: center; padding: 0">
+      <![endif]-->
+
+      <!-- Header -->
       <div style="background-color:transparent;">
-        <div class="block-grid " style="Margin: 0 auto; min-width: 320px; max-width: 640px; overflow-wrap: break-word; word-wrap: break-word; word-break: break-word; background-color: #1aa19c;">
+        <div class="block-grid " style="margin: 0 auto; min-width: 320px; max-width: 640px; overflow-wrap: break-word; word-wrap: break-word; word-break: break-word; background-color: #1aa19c;">
           <div style="border-collapse: collapse;display: table;width: 100%;background-color:#1aa19c;">
-            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:transparent;"><tr><td align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:640px"><tr class="layout-full-width" style="background-color:#1aa19c"><![endif]-->
-            <!--[if (mso)|(IE)]><td align="center" width="640" style="background-color:#1aa19c;width:640px; border-top: 0px solid transparent; border-left: 0px solid transparent; border-bottom: 0px solid transparent; border-right: 0px solid transparent;" valign="top"><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 0px; padding-left: 0px; padding-top:0px; padding-bottom:0px;"><![endif]-->
+            <!--[if (mso)|(IE)]>
+            <table class="standard-table" style="background-color:transparent">
+              <tr>
+                <td style="padding: 0; text-align: center">
+                  <table style="width:640px; border-collapse: collapse; border: 0">
+                    <tr class="layout-full-width" style="background-color:#1aa19c">
+            <![endif]-->
+            <!--[if (mso)|(IE)]>
+            <td style="background-color:#1aa19c;width:640px; border: 0 solid transparent; padding: 0; text-align: center; vertical-align: top">
+              <table style="width: 100%; border-collapse: collapse; border: 0">
+                <tr>
+                  <td style="padding: 0">
+            <![endif]-->
             <div class="col num12" style="min-width: 320px; max-width: 640px; display: table-cell; vertical-align: top; width: 640px;">
               <div style="width:100% !important;">
                 <!--[if (!mso)&(!IE)]><!-->
-                <div style="border-top:0px solid transparent; border-left:0px solid transparent; border-bottom:0px solid transparent; border-right:0px solid transparent; padding-top:0px; padding-bottom:0px; padding-right: 0px; padding-left: 0px;">
+                <div style="border: 0 solid transparent; padding: 0;">
                   <!--<![endif]-->
-                  <table class="divider" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" role="presentation" valign="top">
-                    <tbody>
-                    <tr style="vertical-align: top;" valign="top">
-                      <td class="divider_inner" style="word-break: break-word; vertical-align: top; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding-top: 0px; padding-right: 0px; padding-bottom: 0px; padding-left: 0px;" valign="top">
-                        <table class="divider_content" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-top: 4px solid #78AD1D; width: 100%;" align="center" role="presentation" valign="top">
-                          <tbody>
-                          <tr style="vertical-align: top;" valign="top">
-                            <td style="word-break: break-word; vertical-align: top; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" valign="top"><span></span></td>
-                          </tr>
-                          </tbody>
-                        </table>
-                      </td>
+                  <div class="img-container center fixedwidth" align="center" style="padding-right: 0;padding-left: 0;">
+                    <!--[if mso]>
+                    <table class="standard-table">
+                      <tr style="line-height:0">
+                        <td style="padding: 0; text-align: center">
+                    <![endif]--><img class="center fixedwidth" border="0" src="https://d2j3fegnzkmagm.cloudfront.net/email-banner.png" alt="SFTT Email Banner" title="SFTT Email Banner" style="text-decoration: none; -ms-interpolation-mode: bicubic; border: 0; height: auto; width: 100%; max-width: 640px; display: block;" width="640">
+                    <!--[if mso]>
+                    </td>
                     </tr>
-                    </tbody>
-                  </table>
-                  <div class="img-container center fixedwidth" align="center" style="padding-right: 0px;padding-left: 0px;">
-                    <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr style="line-height:0px"><td style="padding-right: 0px;padding-left: 0px;" align="center"><![endif]--><img class="center fixedwidth" align="center" border="0" src="https://d15k2d11r6t6rl.cloudfront.net/public/users/Integrators/BeeProAgency/549127_530283/Logo%20Header_SFTT.jpg" alt="SFTT Logo" title="SFTT Logo" style="text-decoration: none; -ms-interpolation-mode: bicubic; border: 0; height: auto; width: 100%; max-width: 640px; display: block;" width="640">
-                    <!--[if mso]></td></tr></table><![endif]-->
+                    </table>
+                    <![endif]-->
                   </div>
                   <!--[if (!mso)&(!IE)]><!-->
                 </div>
                 <!--<![endif]-->
               </div>
             </div>
-            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
-            <!--[if (mso)|(IE)]></td></tr></table></td></tr></table><![endif]-->
+            <!--[if (mso)|(IE)]>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
+            <!--[if (mso)|(IE)]>
+            </td>
+            </tr>
+            </table>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
           </div>
         </div>
       </div>
-      <div style="background-color:transparent;">
-        <div class="block-grid " style="Margin: 0 auto; min-width: 320px; max-width: 640px; overflow-wrap: break-word; word-wrap: break-word; word-break: break-word; background-color: #f8f8f9;">
-          <div style="border-collapse: collapse;display: table;width: 100%;background-color:#f8f8f9;">
-            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:transparent;"><tr><td align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:640px"><tr class="layout-full-width" style="background-color:#f8f8f9"><![endif]-->
-            <!--[if (mso)|(IE)]><td align="center" width="640" style="background-color:#f8f8f9;width:640px; border-top: 0px solid transparent; border-left: 0px solid transparent; border-bottom: 0px solid transparent; border-right: 0px solid transparent;" valign="top"><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 0px; padding-left: 0px; padding-top:5px; padding-bottom:5px;"><![endif]-->
-            <div class="col num12" style="min-width: 320px; max-width: 640px; display: table-cell; vertical-align: top; width: 640px;">
-              <div style="width:100% !important;">
-                <!--[if (!mso)&(!IE)]><!-->
-                <div style="border-top:0px solid transparent; border-left:0px solid transparent; border-bottom:0px solid transparent; border-right:0px solid transparent; padding-top:5px; padding-bottom:5px; padding-right: 0px; padding-left: 0px;">
-                  <!--<![endif]-->
-                  <table class="divider" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" role="presentation" valign="top">
-                    <tbody>
-                    <tr style="vertical-align: top;" valign="top">
-                      <td class="divider_inner" style="word-break: break-word; vertical-align: top; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding-top: 10px; padding-right: 0px; padding-bottom: 10px; padding-left: 0px;" valign="top">
-                        <table class="divider_content" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-top: 1px solid #555961; width: 100%;" align="center" role="presentation" valign="top">
-                          <tbody>
-                          <tr style="vertical-align: top;" valign="top">
-                            <td style="word-break: break-word; vertical-align: top; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" valign="top"><span></span></td>
-                          </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                    </tbody>
-                  </table>
-                  <!--[if (!mso)&(!IE)]><!-->
-                </div>
-                <!--<![endif]-->
-              </div>
-            </div>
-            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
-            <!--[if (mso)|(IE)]></td></tr></table></td></tr></table><![endif]-->
-          </div>
-        </div>
-      </div>
-      <div style="background-color:transparent;">
-        <div class="block-grid " style="Margin: 0 auto; min-width: 320px; max-width: 640px; overflow-wrap: break-word; word-wrap: break-word; word-break: break-word; background-color: #fff;">
+
+      <!-- Content -->
+      <div style="background-color: transparent;">
+        <div class="block-grid " style="margin: 0 auto; min-width: 320px; max-width: 640px; overflow-wrap: break-word; word-wrap: break-word; word-break: break-word; background-color: #fff;">
           <div style="border-collapse: collapse;display: table;width: 100%;background-color:#fff;">
-            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:transparent;"><tr><td align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:640px"><tr class="layout-full-width" style="background-color:#fff"><![endif]-->
-            <!--[if (mso)|(IE)]><td align="center" width="640" style="background-color:#fff;width:640px; border-top: 0px solid transparent; border-left: 0px solid transparent; border-bottom: 0px solid transparent; border-right: 0px solid transparent;" valign="top"><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 0px; padding-left: 0px; padding-top:0px; padding-bottom:0px;"><![endif]-->
+            <!--[if (mso)|(IE)]>
+            <table class="standard-table" style="background-color:transparent">
+              <tr>
+                <td style="padding: 0; text-align: center">
+                  <table style="width:640px; border-collapse: collapse; border: 0">
+                    <tr class="layout-full-width" style="background-color:#fff">
+            <![endif]-->
+            <!--[if (mso)|(IE)]>
+            <td style="background-color:#fff;width:640px; border-top: 0 solid transparent; padding: 0; text-align: center; vertical-align: top">
+              <table style="width: 100%; border-collapse: collapse; border: 0">
+                <tr>
+                  <td style="padding: 0">
+            <![endif]-->
             <div class="col num12" style="min-width: 320px; max-width: 640px; display: table-cell; vertical-align: top; width: 640px;">
               <div style="width:100% !important;">
                 <!--[if (!mso)&(!IE)]><!-->
-                <div style="border-top:0px solid transparent; border-left:0px solid transparent; border-bottom:0px solid transparent; border-right:0px solid transparent; padding-top:0px; padding-bottom:0px; padding-right: 0px; padding-left: 0px;">
+                <div style="border:0 solid transparent; padding: 0">
                   <!--<![endif]-->
-                  <table class="divider" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" role="presentation" valign="top">
+
+                  <!-- Divider -->
+                  <table class="divider" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" role="presentation" valign="top">
                     <tbody>
                     <tr style="vertical-align: top;" valign="top">
-                      <td class="divider_inner" style="word-break: break-word; vertical-align: top; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding-top: 50px; padding-right: 0px; padding-bottom: 0px; padding-left: 0px;" valign="top">
-                        <table class="divider_content" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-top: 0px solid #BBBBBB; width: 100%;" align="center" role="presentation" valign="top">
+                      <td class="divider_inner" style="word-break: break-word; vertical-align: top; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding: 50px 0 0 0" valign="top">
+                        <table class="divider_content" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0; border-top: 0 solid #BBBBBB; width: 100%;" align="center" role="presentation" valign="top">
                           <tbody>
                           <tr style="vertical-align: top;" valign="top">
                             <td style="word-break: break-word; vertical-align: top; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" valign="top"><span></span></td>
@@ -220,57 +177,75 @@
                     </tr>
                     </tbody>
                   </table>
-                  <div class="img-container center fixedwidth" align="center" style="padding-right: 0px;padding-left: 0px;">
-                    <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr style="line-height:0px"><td style="padding-right: 0px;padding-left: 0px;" align="center"><![endif]--><img class="center fixedwidth" align="center" border="0" src="https://d15k2d11r6t6rl.cloudfront.net/public/users/Integrators/BeeProAgency/549127_530283/Question_SFTT.jpg" alt="SFTT Email Banner" title="SFTT Email Banner" style="text-decoration: none; -ms-interpolation-mode: bicubic; border: 0; height: auto; width: 100%; max-width: 640px; display: block;" width="640">
-                    <!--[if mso]></td></tr></table><![endif]-->
-                  </div>
-                  <table class="divider" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" role="presentation" valign="top">
-                    <tbody>
-                    <tr style="vertical-align: top;" valign="top">
-                      <td class="divider_inner" style="word-break: break-word; vertical-align: top; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding-top: 50px; padding-right: 0px; padding-bottom: 0px; padding-left: 0px;" valign="top">
-                        <table class="divider_content" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-top: 0px solid #BBBBBB; width: 100%;" align="center" role="presentation" valign="top">
-                          <tbody>
-                          <tr style="vertical-align: top;" valign="top">
-                            <td style="word-break: break-word; vertical-align: top; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" valign="top"><span></span></td>
-                          </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                    </tbody>
-                  </table>
-                  <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 40px; padding-left: 40px; padding-top: 10px; padding-bottom: 10px; font-family: Tahoma, sans-serif"><![endif]-->
-                  <div style="color:#555555;font-family:Montserrat, Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;line-height:1.2;padding-top:10px;padding-right:40px;padding-bottom:10px;padding-left:40px;">
+
+                  <!-- Title -->
+                  <!--[if mso]>
+                  <table style="width: 100%; border-collapse: collapse; border: 0">
+                    <tr>
+                      <td style="padding: 10px 40px; font-family: Tahoma, sans-serif">
+                  <![endif]-->
+                  <div style="color:#555555;font-family:Montserrat, Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;line-height:1.2; padding: 10px 40px">
                     <div style="line-height: 1.2; font-size: 12px; color: #555555; font-family: Montserrat, Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif; mso-line-height-alt: 14px;">
                       <p style="font-size: 30px; line-height: 1.2; text-align: center; word-break: break-word; mso-line-height-alt: 36px; margin: 0;"><span style="font-size: 30px; color: #2b303a;"><strong>Forgot Your Password?</strong></span></p>
                     </div>
                   </div>
-                  <!--[if mso]></td></tr></table><![endif]-->
-                  <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 30px; padding-left: 30px; padding-top: 10px; padding-bottom: 10px; font-family: Tahoma, sans-serif"><![endif]-->
-                  <div style="color:#555555;font-family:Montserrat, Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;line-height:1.5;padding-top:10px;padding-right:30px;padding-bottom:10px;padding-left:30px;">
+
+                  <!-- Paragraph -->
+                  <!--[if mso]>
+                  </td>
+                  </tr>
+                  </table>
+                  <![endif]-->
+                  <!--[if mso]>
+                  <table style="width: 100%; border-collapse: collapse; border: 0">
+                    <tr>
+                      <td style="padding: 10px 30px; font-family: Tahoma, sans-serif">
+                  <![endif]-->
+                  <div style="color:#555555;font-family:Montserrat, Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;line-height:1.5; padding: 10px 30px">
                     <div style="line-height: 1.5; font-size: 12px; font-family: Montserrat, Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif; color: #555555; mso-line-height-alt: 18px;">
                       <p style="font-size: 15px; line-height: 1.5; text-align: center; word-break: break-word; font-family: inherit; mso-line-height-alt: 23px; margin: 0;"><span style="color: #808389; font-size: 15px;">No problem! Click on the button below to be redirected to a page that can help you create a new password for your account.&nbsp;</span></p>
                     </div>
                   </div>
-                  <!--[if mso]></td></tr></table><![endif]-->
-                  <div class="button-container" align="center" style="padding-top:15px;padding-right:10px;padding-bottom:0px;padding-left:10px;">
-                    <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-spacing: 0; border-collapse: collapse; mso-table-lspace:0pt; mso-table-rspace:0pt;"><tr><td style="padding-top: 15px; padding-right: 10px; padding-bottom: 0px; padding-left: 10px" align="center"><v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="" style="height:46.5pt; width:202.5pt; v-text-anchor:middle;" arcsize="97%" stroke="false" fillcolor="#a2d64c"><w:anchorlock/><v:textbox inset="0,0,0,0"><center style="color:#ffffff; font-family:Tahoma, sans-serif; font-size:16px"><![endif]-->
+
+                  <!-- Button -->
+                  <!--[if mso]>
+                  </td>
+                  </tr>
+                  </table>
+                  <![endif]-->
+                  <div class="button-container" align="center" style="padding: 15px 10px 0">
+                    <!--[if mso]>
+                    <table style="width: 100%; border-collapse: collapse; border: 0; border-spacing: 0; mso-table-lspace:0; mso-table-rspace:0;">
+                      <tr>
+                        <td style="padding: 15px 10px 0; text-align: center">
+                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="" style="height:46.5pt; width:202.5pt; v-text-anchor:middle;" arcsize="97%" stroke="false" fillcolor="#99c356">
+                            <w:anchorlock/>
+                            <v:textbox inset="0,0,0,0">
+                    <![endif]-->
                     <a style="text-decoration: none; font-weight: bold; color: white;" href="${link}">
-                    <div style="text-decoration:none;display:inline-block;color:#ffffff;background-color:#a2d64c;border-radius:60px;-webkit-border-radius:60px;-moz-border-radius:60px;width:auto; width:auto;;border-top:1px solid #a2d64c;border-right:1px solid #a2d64c;border-bottom:1px solid #a2d64c;border-left:1px solid #a2d64c;padding-top:15px;padding-bottom:15px;font-family:Montserrat, Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;text-align:center;mso-border-alt:none;word-break:keep-all;">
-                      <span style="padding-left:30px;padding-right:30px;font-size:16px;display:inline-block;">
-                        <span style="font-size: 16px; margin: 0; line-height: 2; word-break: break-word; mso-line-height-alt: 32px;">
-                          <strong>Change Password</strong>
-                        </span>
-                      </span>
-                    </div>
+                      <div style="text-decoration:none;display:inline-block;color:#ffffff;background-color:#a2d64c;border-radius:60px;-webkit-border-radius:60px;-moz-border-radius:60px;width:auto;border-top:1px solid #a2d64c;border-right:1px solid #a2d64c;border-bottom:1px solid #a2d64c;border-left:1px solid #a2d64c;padding-top:15px;padding-bottom:15px;font-family:Montserrat, Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;text-align:center;mso-border-alt:none;word-break:keep-all;">
+                                                                  <span style="padding-left:30px;padding-right:30px;font-size:16px;display:inline-block;">
+                                                                  <span style="font-size: 16px; margin: 0; line-height: 2; word-break: break-word; mso-line-height-alt: 32px;">
+                                                                  <strong>Change Password</strong>
+                                                                  </span>
+                                                                  </span>
+                      </div>
                     </a>
-                    <!--[if mso]></center></v:textbox></v:roundrect></td></tr></table><![endif]-->
+                    <!--[if mso]>
+                    </v:textbox>
+                    </v:roundrect>
+                    </td>
+                    </tr>
+                    </table>
+                    <![endif]-->
                   </div>
-                  <table class="divider" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" role="presentation" valign="top">
+
+                  <!-- Divider -->
+                  <table class="divider" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" role="presentation" valign="top">
                     <tbody>
                     <tr style="vertical-align: top;" valign="top">
-                      <td class="divider_inner" style="word-break: break-word; vertical-align: top; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding-top: 60px; padding-right: 0px; padding-bottom: 12px; padding-left: 0px;" valign="top">
-                        <table class="divider_content" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-top: 0px solid #BBBBBB; width: 100%;" align="center" role="presentation" valign="top">
+                      <td class="divider_inner" style="word-break: break-word; vertical-align: top; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding: 60px 0 12px" valign="top">
+                        <table class="divider_content" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0; border-top: 0 solid #BBBBBB; width: 100%;" align="center" role="presentation" valign="top">
                           <tbody>
                           <tr style="vertical-align: top;" valign="top">
                             <td style="word-break: break-word; vertical-align: top; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" valign="top"><span></span></td>
@@ -286,71 +261,55 @@
                 <!--<![endif]-->
               </div>
             </div>
-            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
-            <!--[if (mso)|(IE)]></td></tr></table></td></tr></table><![endif]-->
+            <!--[if (mso)|(IE)]>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
+            <!--[if (mso)|(IE)]>
+            </td>
+            </tr>
+            </table>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
           </div>
         </div>
       </div>
-      <div style="background-color:transparent;">
-        <div class="block-grid " style="Margin: 0 auto; min-width: 320px; max-width: 640px; overflow-wrap: break-word; word-wrap: break-word; word-break: break-word; background-color: #f8f8f9;">
-          <div style="border-collapse: collapse;display: table;width: 100%;background-color:#f8f8f9;">
-            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:transparent;"><tr><td align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:640px"><tr class="layout-full-width" style="background-color:#f8f8f9"><![endif]-->
-            <!--[if (mso)|(IE)]><td align="center" width="640" style="background-color:#f8f8f9;width:640px; border-top: 0px solid transparent; border-left: 0px solid transparent; border-bottom: 0px solid transparent; border-right: 0px solid transparent;" valign="top"><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 0px; padding-left: 0px; padding-top:5px; padding-bottom:5px;"><![endif]-->
-            <div class="col num12" style="min-width: 320px; max-width: 640px; display: table-cell; vertical-align: top; width: 640px;">
-              <div style="width:100% !important;">
-                <!--[if (!mso)&(!IE)]><!-->
-                <div style="border-top:0px solid transparent; border-left:0px solid transparent; border-bottom:0px solid transparent; border-right:0px solid transparent; padding-top:5px; padding-bottom:5px; padding-right: 0px; padding-left: 0px;">
-                  <!--<![endif]-->
-                  <table class="divider" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" role="presentation" valign="top">
-                    <tbody>
-                    <tr style="vertical-align: top;" valign="top">
-                      <td class="divider_inner" style="word-break: break-word; vertical-align: top; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding-top: 10px; padding-right: 0px; padding-bottom: 10px; padding-left: 0px;" valign="top">
-                        <table class="divider_content" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-top: 1px solid #555961; width: 100%;" align="center" role="presentation" valign="top">
-                          <tbody>
-                          <tr style="vertical-align: top;" valign="top">
-                            <td style="word-break: break-word; vertical-align: top; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" valign="top"><span></span></td>
-                          </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                    </tbody>
-                  </table>
-                  <!--[if (!mso)&(!IE)]><!-->
-                </div>
-                <!--<![endif]-->
-              </div>
-            </div>
-            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
-            <!--[if (mso)|(IE)]></td></tr></table></td></tr></table><![endif]-->
-          </div>
-        </div>
-      </div>
+
+      <!-- Footer -->
       <div style="background-color:transparent;">
         <div class="block-grid " style="Margin: 0 auto; min-width: 320px; max-width: 640px; overflow-wrap: break-word; word-wrap: break-word; word-break: break-word; background-color: #ffffff;">
           <div style="border-collapse: collapse;display: table;width: 100%;background-color:#ffffff;">
-            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:transparent;"><tr><td align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:640px"><tr class="layout-full-width" style="background-color:#ffffff"><![endif]-->
-            <!--[if (mso)|(IE)]><td align="center" width="640" style="background-color:#ffffff;width:640px; border-top: 0px solid transparent; border-left: 0px solid transparent; border-bottom: 0px solid transparent; border-right: 0px solid transparent;" valign="top"><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 0px; padding-left: 0px; padding-top:0px; padding-bottom:0px;"><![endif]-->
+            <!--[if (mso)|(IE)]>
+            <table style="background-color:transparent; width: 100%; border-collapse: collapse; border: 0">
+              <tr>
+                <td style="padding: 0; text-align: center">
+                  <table style="width:640px; border-collapse: collapse; border: 0">
+                    <tr class="layout-full-width" style="background-color:#ffffff">
+            <![endif]-->
+            <!--[if (mso)|(IE)]>
+            <td style="background-color:#ffffff;width:640px; border-top: 0 solid transparent; padding: 0; text-align: center; vertical-align: top">
+              <table style="width: 100%; border-collapse: collapse; border: 0">
+                <tr>
+                  <td style="padding: 0">
+            <![endif]-->
             <div class="col num12" style="min-width: 320px; max-width: 640px; display: table-cell; vertical-align: top; width: 640px;">
               <div style="width:100% !important;">
                 <!--[if (!mso)&(!IE)]><!-->
-                <div style="border-top:0px solid transparent; border-left:0px solid transparent; border-bottom:0px solid transparent; border-right:0px solid transparent; padding-top:0px; padding-bottom:0px; padding-right: 0px; padding-left: 0px;">
+                <div style="border: 0 solid transparent; padding: 0">
                   <!--<![endif]-->
-                  <div class="img-container center autowidth" align="center" style="padding-right: 0px;padding-left: 0px;">
-                    <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr style="line-height:0px"><td style="padding-right: 0px;padding-left: 0px;" align="center"><![endif]--><img class="center autowidth" align="center" border="0" src="https://d15k2d11r6t6rl.cloudfront.net/public/users/Integrators/BeeProAgency/549127_530283/Light%20Block.jpg" alt="Color Block" title="Color Block" style="text-decoration: none; -ms-interpolation-mode: bicubic; border: 0; height: auto; width: 100%; max-width: 640px; display: block;" width="640">
-                    <!--[if mso]></td></tr></table><![endif]-->
-                  </div>
-                  <table class="social_icons" cellpadding="0" cellspacing="0" width="100%" role="presentation" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top">
+
+                  <!-- Content-Footer Divider -->
+                  <table class="divider" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" role="presentation" valign="top">
                     <tbody>
                     <tr style="vertical-align: top;" valign="top">
-                      <td style="word-break: break-word; vertical-align: top; padding-top: 28px; padding-right: 10px; padding-bottom: 10px; padding-left: 10px;" valign="top">
-                        <table class="social_table" align="center" cellpadding="0" cellspacing="0" role="presentation" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-tspace: 0; mso-table-rspace: 0; mso-table-bspace: 0; mso-table-lspace: 0;" valign="top">
+                      <td class="divider_inner" style="word-break: break-word; vertical-align: top; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding: 0" valign="top">
+                        <table class="divider_content" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0; border-top: 10px solid #99c356; width: 100%;" align="center" role="presentation" valign="top">
                           <tbody>
-                          <tr style="vertical-align: top; display: inline-block; text-align: center;" align="center" valign="top">
-                            <td style="word-break: break-word; vertical-align: top; padding-bottom: 0; padding-right: 5px; padding-left: 5px;" valign="top"><a href="https://www.sfttbos.org/" target="_blank"><img width="32" height="32" src="https://d2fi4ri5dhpqd1.cloudfront.net/public/resources/social-networks-icon-sets/t-outline-circle-dark-gray/website@2x.png" alt="Web Site" title="Web Site" style="text-decoration: none; -ms-interpolation-mode: bicubic; height: auto; border: none; display: block;"></a></td>
-                            <td style="word-break: break-word; vertical-align: top; padding-bottom: 0; padding-right: 5px; padding-left: 5px;" valign="top"><a href="https://www.facebook.com/SFTTBos/" target="_blank"><img width="32" height="32" src="https://d2fi4ri5dhpqd1.cloudfront.net/public/resources/social-networks-icon-sets/t-outline-circle-dark-gray/facebook@2x.png" alt="Facebook" title="Facebook" style="text-decoration: none; -ms-interpolation-mode: bicubic; height: auto; border: none; display: block;"></a></td>
-                            <td style="word-break: break-word; vertical-align: top; padding-bottom: 0; padding-right: 5px; padding-left: 5px;" valign="top"><a href="https://twitter.com/SFTTBos" target="_blank"><img width="32" height="32" src="https://d2fi4ri5dhpqd1.cloudfront.net/public/resources/social-networks-icon-sets/t-outline-circle-dark-gray/twitter@2x.png" alt="Twitter" title="Twitter" style="text-decoration: none; -ms-interpolation-mode: bicubic; height: auto; border: none; display: block;"></a></td>
-                            <td style="word-break: break-word; vertical-align: top; padding-bottom: 0; padding-right: 5px; padding-left: 5px;" valign="top"><a href="https://www.instagram.com/SFTTBos/" target="_blank"><img width="32" height="32" src="https://d2fi4ri5dhpqd1.cloudfront.net/public/resources/social-networks-icon-sets/t-outline-circle-dark-gray/instagram@2x.png" alt="Instagram" title="Instagram" style="text-decoration: none; -ms-interpolation-mode: bicubic; height: auto; border: none; display: block;"></a></td>
+                          <tr style="vertical-align: top;" valign="top">
+                            <td style="word-break: break-word; vertical-align: top; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" valign="top"><span></span></td>
                           </tr>
                           </tbody>
                         </table>
@@ -358,18 +317,50 @@
                     </tr>
                     </tbody>
                   </table>
-                  <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 45px; padding-left: 45px; padding-top: 15px; padding-bottom: 10px; font-family: Tahoma, sans-serif"><![endif]-->
-                  <div style="color:#555555;font-family:Montserrat, Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;line-height:1.5;padding-top:15px;padding-right:45px;padding-bottom:10px;padding-left:45px;">
+
+                  <!-- Social Links -->
+                  <table class="social_icons" cellpadding="0" cellspacing="0" width="100%" role="presentation" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0;" valign="top">
+                    <tbody>
+                    <tr style="vertical-align: top;" valign="top">
+                      <td style="word-break: break-word; vertical-align: top; padding: 28px 10px 10px;" valign="top">
+                        <table class="social_table" align="center" cellpadding="0" cellspacing="0" role="presentation" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-tspace: 0; mso-table-rspace: 0; mso-table-bspace: 0; mso-table-lspace: 0;" valign="top">
+                          <tbody>
+                          <tr style="vertical-align: top; display: inline-block; text-align: center;" align="center" valign="top">
+                            <td style="word-break: break-word; vertical-align: top; padding-bottom: 0; padding-right: 5px; padding-left: 5px;" valign="top"><a href="https://treeboston.org/" target="_blank"><img width="32" height="32" src="https://d2fi4ri5dhpqd1.cloudfront.net/public/resources/social-networks-icon-sets/t-outline-circle-dark-gray/website@2x.png" alt="Website" title="Website" style="text-decoration: none; -ms-interpolation-mode: bicubic; height: auto; border: none; display: block;"></a></td>
+                            <td style="word-break: break-word; vertical-align: top; padding-bottom: 0; padding-right: 5px; padding-left: 5px;" valign="top"><a href="https://www.facebook.com/TreesBoston/" target="_blank"><img width="32" height="32" src="https://d2fi4ri5dhpqd1.cloudfront.net/public/resources/social-networks-icon-sets/t-outline-circle-dark-gray/facebook@2x.png" alt="Facebook" title="Facebook" style="text-decoration: none; -ms-interpolation-mode: bicubic; height: auto; border: none; display: block;"></a></td>
+                            <td style="word-break: break-word; vertical-align: top; padding-bottom: 0; padding-right: 5px; padding-left: 5px;" valign="top"><a href="https://twitter.com/Trees_Boston" target="_blank"><img width="32" height="32" src="https://d2fi4ri5dhpqd1.cloudfront.net/public/resources/social-networks-icon-sets/t-outline-circle-dark-gray/twitter@2x.png" alt="Twitter" title="Twitter" style="text-decoration: none; -ms-interpolation-mode: bicubic; height: auto; border: none; display: block;"></a></td>
+                            <td style="word-break: break-word; vertical-align: top; padding-bottom: 0; padding-right: 5px; padding-left: 5px;" valign="top"><a href="https://www.instagram.com/trees_boston/" target="_blank"><img width="32" height="32" src="https://d2fi4ri5dhpqd1.cloudfront.net/public/resources/social-networks-icon-sets/t-outline-circle-dark-gray/instagram@2x.png" alt="Instagram" title="Instagram" style="text-decoration: none; -ms-interpolation-mode: bicubic; height: auto; border: none; display: block;"></a></td>
+                          </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                    </tbody>
+                  </table>
+
+                  <!-- Caption -->
+                  <!--[if mso]>
+                  <table class="standard-table">
+                    <tr>
+                      <td style="padding: 15px 45px 10px; font-family: Tahoma, sans-serif">
+                  <![endif]-->
+                  <div style="color:#555555;font-family:Montserrat, Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;line-height:1.5; padding:15px 45px 10px;">
                     <div style="line-height: 1.5; font-size: 12px; font-family: Montserrat, Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif; color: #555555; mso-line-height-alt: 18px;">
                       <p style="font-size: 12px; line-height: 1.5; word-break: break-word; text-align: center; font-family: inherit; mso-line-height-alt: 18px; margin: 0;"><span style="font-size: 12px;">We aim&nbsp;to&nbsp;improve&nbsp;the size and health of the urban forest in&nbsp;Boston, with a focus on under-served and under-canopied neighborhoods.</span></p>
                     </div>
                   </div>
-                  <!--[if mso]></td></tr></table><![endif]-->
-                  <table class="divider" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" role="presentation" valign="top">
+                  <!--[if mso]>
+                  </td>
+                  </tr>
+                  </table>
+                  <![endif]-->
+
+                  <!-- Thin Footer Block -->
+                  <table class="divider" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" role="presentation" valign="top">
                     <tbody>
                     <tr style="vertical-align: top;" valign="top">
-                      <td class="divider_inner" style="word-break: break-word; vertical-align: top; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding-top: 25px; padding-right: 40px; padding-bottom: 10px; padding-left: 40px;" valign="top">
-                        <table class="divider_content" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-top: 1px solid #555961; width: 100%;" align="center" role="presentation" valign="top">
+                      <td class="divider_inner" style="word-break: break-word; vertical-align: top; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding: 25px 40px 10px;" valign="top">
+                        <table class="divider_content" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0; border-top: 1px solid #555961; width: 100%;" align="center" role="presentation" valign="top">
                           <tbody>
                           <tr style="vertical-align: top;" valign="top">
                             <td style="word-break: break-word; vertical-align: top; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" valign="top"><span></span></td>
@@ -380,11 +371,13 @@
                     </tr>
                     </tbody>
                   </table>
-                  <table class="divider" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" role="presentation" valign="top">
+
+                  <!-- Footer Block -->
+                  <table class="divider" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" role="presentation" valign="top">
                     <tbody>
                     <tr style="vertical-align: top;" valign="top">
-                      <td class="divider_inner" style="word-break: break-word; vertical-align: top; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding-top: 0px; padding-right: 0px; padding-bottom: 0px; padding-left: 0px;" valign="top">
-                        <table class="divider_content" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-top: 4px solid #9FE132; width: 100%;" align="center" role="presentation" valign="top">
+                      <td class="divider_inner" style="word-break: break-word; vertical-align: top; min-width: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding: 0;" valign="top">
+                        <table class="divider_content" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed; vertical-align: top; border-spacing: 0; border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0; border-top: 30px solid #3A681A; width: 100%;" align="center" role="presentation" valign="top">
                           <tbody>
                           <tr style="vertical-align: top;" valign="top">
                             <td style="word-break: break-word; vertical-align: top; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;" valign="top"><span></span></td>
@@ -400,17 +393,33 @@
                 <!--<![endif]-->
               </div>
             </div>
-            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
-            <!--[if (mso)|(IE)]></td></tr></table></td></tr></table><![endif]-->
+            <!--[if (mso)|(IE)]>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
+            <!--[if (mso)|(IE)]>
+            </td>
+            </tr>
+            </table>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
           </div>
         </div>
       </div>
-      <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+      <!--[if (mso)|(IE)]>
+      </td>
+      </tr>
+      </table>
+      <![endif]-->
     </td>
   </tr>
   </tbody>
 </table>
-<!--[if (IE)]></div><![endif]-->
+<!--[if (IE)]>
+</div>
+<![endif]-->
 </body>
-
 </html>


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/2pwzzhx)

Updates the password change request email template for a more aesthetic user experience.

## This PR

- Changed styling according to the design provided by SFTT
- Fixed broken image links
  - Created a new S3 bucket and CloudFront distribution to host new email images (and other public content)
    - Enabled public access through CloudFront Origin Access Identity ([more information + why](https://www.stormit.cloud/post/cloudfront-origin-access-identity))
  - Used divs instead of images where possible for greater stability
- Cleaned up HTML to improve readability
  - Followed IntelliJ suggestions to use CSS shorthands + update outdated attributes
  - Added comments to break up sections
  - Formatted HTML using [FreeFormatter](https://www.freeformatter.com/html-formatter.html) (2 spaces per indent level)

## Screenshots

Desktop, Gmail
![image](https://user-images.githubusercontent.com/22990100/162540813-0bfaebf6-f674-4ba6-936a-e982f56f1ab6.png)

Desktop, Outlook, Dark Mode
![image](https://user-images.githubusercontent.com/22990100/162540757-137e3ffb-7075-4ef2-8755-e261f3c1e752.png)

Mobile, Gmail, Dark Mode
![image](https://user-images.githubusercontent.com/22990100/162540584-99720187-a387-4863-b84e-4e68696e1f2e.png)

## Verification Steps
- Viewed the HTML file in a browser and made sure the email looked reasonable.
- Sent the email (with the emailer) to an Outlook and Gmail address, made sure it looked reasonable on Desktop + Mobile