### PR TITLE
Specify site ID in addSite route

### DIFF
--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -218,6 +218,9 @@ public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
 
     SiteEntriesRecord siteEntriesRecord = db.newRecord(SITE_ENTRIES);
 
+    int newSiteEntriesId = db.select(max(SITE_ENTRIES.ID)).from(SITE_ENTRIES).fetchOne(0, Integer.class) + 1;
+
+    siteEntriesRecord.setId(newSiteEntriesId);
     siteEntriesRecord.setUserId(userData.getUserId());
     siteEntriesRecord.setSiteId(sitesRecord.getId());
     siteEntriesRecord.setUpdatedAt(new Timestamp(System.currentTimeMillis()));


### PR DESCRIPTION
Explicitly specify the ID of the `siteEntriesRecord` when creating one as it was giving me a duplicate primary key error without it when I was testing the add site form in the frontend (similar to line 206 of `ProtectedSiteProcessorImpl.java` with `sitesRecord`).