### PR TITLE
Rename getNeighborhood()

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/site/GetSiteResponse.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/GetSiteResponse.java
@@ -63,7 +63,7 @@ public class GetSiteResponse {
     return address;
   }
 
-  public Integer getNeighborhood() {
+  public Integer getNeighborhoodId() {
     return neighborhoodId;
   }
 


### PR DESCRIPTION
Rename `getNeighborhood()` in `GetSiteResponse.java` to `getNeighborhoodId()` to match the fix made in #94 to change the neighborhood field returned by the getSite route to neighborhood ID. This also fixes the neighborhood dropdown not showing the neighborhood name correctly.

![before](https://user-images.githubusercontent.com/33704204/183312199-e837432f-bff5-4795-a091-2e37d6ce5eca.png)
![after](https://user-images.githubusercontent.com/33704204/183312202-db8643a3-d9cb-43e8-97e6-50c91fa47cbc.png)