### PR TITLE
Child Account Functionality

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -7,6 +7,7 @@ import com.codeforcommunity.dto.site.AdoptedSitesResponse;
 import com.codeforcommunity.dto.site.EditSiteRequest;
 import com.codeforcommunity.dto.site.NameSiteEntryRequest;
 import com.codeforcommunity.dto.site.ParentAdoptSiteRequest;
+import com.codeforcommunity.dto.site.ParentRecordStewardshipRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import java.sql.Date;
@@ -24,7 +25,7 @@ public interface IProtectedSiteProcessor {
   /** Removes the record in the adopted sites table linking the site to its current adopter */
   void forceUnadoptSite(JWTData userData, int siteId);
 
-  /** Adopts a tree for the Child through the Parent Account **/
+  /** Adopts a tree for a child account through the parent account **/
   void parentAdoptSite(JWTData parentUserData, int siteId, ParentAdoptSiteRequest parentAdoptSiteRequest,
                        Date dateAdopted);
 
@@ -34,6 +35,11 @@ public interface IProtectedSiteProcessor {
   /** Records a new stewardship activity in the stewardship table linked to the given site */
   void recordStewardship(
       JWTData userData, int siteId, RecordStewardshipRequest recordStewardshipRequest);
+
+  /** Records a new stewardship activity for a child account through a parent account */
+  void parentRecordStewardship(
+      JWTData userData, int siteId, ParentRecordStewardshipRequest parentRecordStewardshipRequest);
+
 
   /** Creates a new site with entries in the sites and siteEntries tables */
   void addSite(JWTData userData, AddSiteRequest addSiteRequest);

--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -6,6 +6,7 @@ import com.codeforcommunity.dto.site.AddSitesRequest;
 import com.codeforcommunity.dto.site.AdoptedSitesResponse;
 import com.codeforcommunity.dto.site.EditSiteRequest;
 import com.codeforcommunity.dto.site.NameSiteEntryRequest;
+import com.codeforcommunity.dto.site.ParentAdoptSiteRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import java.sql.Date;
@@ -22,6 +23,10 @@ public interface IProtectedSiteProcessor {
 
   /** Removes the record in the adopted sites table linking the site to its current adopter */
   void forceUnadoptSite(JWTData userData, int siteId);
+
+  /** Adopts a tree for the Child through the Parent Account **/
+  void parentAdoptSite(JWTData parentUserData, int siteId, ParentAdoptSiteRequest parentAdoptSiteRequest,
+                       Date dateAdopted);
 
   /** Get users adopted sites */
   AdoptedSitesResponse getAdoptedSites(JWTData userData);

--- a/api/src/main/java/com/codeforcommunity/dto/site/ParentAdoptSiteRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/ParentAdoptSiteRequest.java
@@ -1,0 +1,30 @@
+package com.codeforcommunity.dto.site;
+
+import com.codeforcommunity.dto.ApiDto;
+import com.codeforcommunity.exceptions.HandledException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ParentAdoptSiteRequest extends ApiDto {
+  private Integer childUserId;
+
+  public Integer getChildUserId() {
+    return childUserId;
+  }
+
+  public void setChildUserId(Integer childUserId) {
+    this.childUserId = childUserId;
+  }
+
+  @Override
+  public List<String> validateFields(String fieldPrefix) throws HandledException {
+    String fieldName = fieldPrefix + "parent_adopt_site_request.";
+    List<String> fields = new ArrayList<>();
+
+    if (childUserId == null) {
+      fields.add(fieldName + "child_user_id");
+    }
+    return fields;
+  }
+}

--- a/api/src/main/java/com/codeforcommunity/dto/site/ParentAdoptSiteRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/ParentAdoptSiteRequest.java
@@ -25,6 +25,7 @@ public class ParentAdoptSiteRequest extends ApiDto {
     if (childUserId == null) {
       fields.add(fieldName + "child_user_id");
     }
+
     return fields;
   }
 }

--- a/api/src/main/java/com/codeforcommunity/dto/site/ParentRecordStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/ParentRecordStewardshipRequest.java
@@ -7,12 +7,22 @@ import java.util.List;
 
 public class ParentRecordStewardshipRequest extends RecordStewardshipRequest {
 
-  Integer childUserId;
+  private Integer childUserId;
 
-  public ParentRecordStewardshipRequest(Integer childUserId, Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded) {
+  public ParentRecordStewardshipRequest(
+      Date date,
+      boolean watered,
+      boolean mulched,
+      boolean cleaned,
+      boolean weeded,
+      Integer childUserId) {
     super(date, watered, mulched, cleaned, weeded);
     this.childUserId = childUserId;
   }
+
+  private ParentRecordStewardshipRequest() {
+    super();
+  };
 
   public Integer getChildUserId() {
     return childUserId;

--- a/api/src/main/java/com/codeforcommunity/dto/site/ParentRecordStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/ParentRecordStewardshipRequest.java
@@ -1,0 +1,37 @@
+package com.codeforcommunity.dto.site;
+
+import com.codeforcommunity.exceptions.HandledException;
+
+import java.sql.Date;
+import java.util.List;
+
+public class ParentRecordStewardshipRequest extends RecordStewardshipRequest {
+
+  Integer childUserId;
+
+  public ParentRecordStewardshipRequest(Integer childUserId, Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded) {
+    super(date, watered, mulched, cleaned, weeded);
+    this.childUserId = childUserId;
+  }
+
+  public Integer getChildUserId() {
+    return childUserId;
+  }
+
+  public void setChildUserId(Integer childUserId) {
+    this.childUserId = childUserId;
+  }
+
+  @Override
+  public List<String> validateFields(String fieldPrefix) throws HandledException {
+    String fieldName = fieldPrefix + "parent_record_stewardship_request.";
+    List<String> fields = super.validateFields(fieldPrefix + "parent_");
+
+    if (childUserId == null) {
+      fields.add(fieldName + "child_user_id");
+    }
+
+    return fields;
+  }
+
+}

--- a/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
@@ -24,7 +24,7 @@ public class RecordStewardshipRequest extends ApiDto {
     this.weeded = weeded;
   }
 
-  private RecordStewardshipRequest() {}
+  protected RecordStewardshipRequest() {}
 
   public java.sql.Date getDate() {
     return date;

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -10,6 +10,7 @@ import com.codeforcommunity.dto.site.AdoptedSitesResponse;
 import com.codeforcommunity.dto.site.EditSiteRequest;
 import com.codeforcommunity.dto.site.NameSiteEntryRequest;
 import com.codeforcommunity.dto.site.ParentAdoptSiteRequest;
+import com.codeforcommunity.dto.site.ParentRecordStewardshipRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import com.codeforcommunity.rest.IRouter;
@@ -35,10 +36,12 @@ public class ProtectedSiteRouter implements IRouter {
     Router router = Router.router(vertx);
 
     registerAdoptSite(router);
+    registerParentAdoptSite(router);
     registerUnadoptSite(router);
     registerForceUnadoptSite(router);
     registerGetAdoptedSitesRoute(router);
     registerRecordStewardship(router);
+    registerParentRecordStewardship(router);
     registerAddSite(router);
     registerUpdateSite(router);
     registerDeleteSite(router);
@@ -60,6 +63,23 @@ public class ProtectedSiteRouter implements IRouter {
     int siteId = RestFunctions.getRequestParameterAsInt(ctx.request(), "site_id");
 
     processor.adoptSite(userData, siteId, Date.valueOf(LocalDate.now()));
+
+    end(ctx.response(), 200);
+  }
+
+  private void registerParentAdoptSite(Router router) {
+    Route parentAdoptSiteRoute = router.post("/:site_id/parent_adopt");
+    parentAdoptSiteRoute.handler(this::handleParentAdoptSiteRoute);
+  }
+
+  private void handleParentAdoptSiteRoute(RoutingContext ctx) {
+    JWTData parentUserData = ctx.get("jwt_data");
+    int siteId = RestFunctions.getRequestParameterAsInt(ctx.request(), "site_id");
+
+    ParentAdoptSiteRequest parentAdoptSiteRequest =
+        RestFunctions.getJsonBodyAsClass(ctx, ParentAdoptSiteRequest.class);
+
+    processor.parentAdoptSite(parentUserData, siteId, parentAdoptSiteRequest, Date.valueOf(LocalDate.now()));
 
     end(ctx.response(), 200);
   }
@@ -92,23 +112,6 @@ public class ProtectedSiteRouter implements IRouter {
     end(ctx.response(), 200);
   }
 
-  private void registerParentAdoptSite(Router router) {
-    Route parentAdoptSiteRoute = router.post("/:site_id/parent_adopt");
-    parentAdoptSiteRoute.handler(this::handleParentAdoptSiteRoute);
-  }
-
-  private void handleParentAdoptSiteRoute(RoutingContext ctx) {
-    JWTData parentUserData = ctx.get("jwt_data");
-    int siteId = RestFunctions.getRequestParameterAsInt(ctx.request(), "site_id");
-
-    ParentAdoptSiteRequest parentAdoptSiteRequest =
-        RestFunctions.getJsonBodyAsClass(ctx, ParentAdoptSiteRequest.class);
-
-    processor.parentAdoptSite(parentUserData, siteId, parentAdoptSiteRequest, Date.valueOf(LocalDate.now()));
-
-    end(ctx.response(), 200);
-  }
-
   private void registerGetAdoptedSitesRoute(Router router) {
     Route getAdoptedSitesRoute = router.get("/adopted_sites");
     getAdoptedSitesRoute.handler(this::handleGetAdoptedSitesRoute);
@@ -135,6 +138,23 @@ public class ProtectedSiteRouter implements IRouter {
         RestFunctions.getJsonBodyAsClass(ctx, RecordStewardshipRequest.class);
 
     processor.recordStewardship(userData, siteId, recordStewardshipRequest);
+
+    end(ctx.response(), 200);
+  }
+
+  private void registerParentRecordStewardship(Router router) {
+    Route recordParentStewardshipRoute = router.post("/:site_id/parent_record_stewardship");
+    recordParentStewardshipRoute.handler(this::handleParentRecordStewardshipRoute);
+  }
+
+  private void handleParentRecordStewardshipRoute(RoutingContext ctx) {
+    JWTData userData = ctx.get("jwt_data");
+    int siteId = RestFunctions.getRequestParameterAsInt(ctx.request(), "site_id");
+
+    ParentRecordStewardshipRequest parentRecordStewardshipRequest =
+        RestFunctions.getJsonBodyAsClass(ctx, ParentRecordStewardshipRequest.class);
+
+    processor.parentRecordStewardship(userData, siteId, parentRecordStewardshipRequest);
 
     end(ctx.response(), 200);
   }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -9,6 +9,7 @@ import com.codeforcommunity.dto.site.AddSitesRequest;
 import com.codeforcommunity.dto.site.AdoptedSitesResponse;
 import com.codeforcommunity.dto.site.EditSiteRequest;
 import com.codeforcommunity.dto.site.NameSiteEntryRequest;
+import com.codeforcommunity.dto.site.ParentAdoptSiteRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import com.codeforcommunity.rest.IRouter;
@@ -87,6 +88,23 @@ public class ProtectedSiteRouter implements IRouter {
     int siteId = RestFunctions.getRequestParameterAsInt(ctx.request(), "site_id");
 
     processor.forceUnadoptSite(userData, siteId);
+
+    end(ctx.response(), 200);
+  }
+
+  private void registerParentAdoptSite(Router router) {
+    Route parentAdoptSiteRoute = router.post("/:site_id/parent_adopt");
+    parentAdoptSiteRoute.handler(this::handleParentAdoptSiteRoute);
+  }
+
+  private void handleParentAdoptSiteRoute(RoutingContext ctx) {
+    JWTData parentUserData = ctx.get("jwt_data");
+    int siteId = RestFunctions.getRequestParameterAsInt(ctx.request(), "site_id");
+
+    ParentAdoptSiteRequest parentAdoptSiteRequest =
+        RestFunctions.getJsonBodyAsClass(ctx, ParentAdoptSiteRequest.class);
+
+    processor.parentAdoptSite(parentUserData, siteId, parentAdoptSiteRequest, Date.valueOf(LocalDate.now()));
 
     end(ctx.response(), 200);
   }


### PR DESCRIPTION
Worked with @mayazeldin to create a new route to handle parents adopting sites for a specified child and a new route to handle parents recording stewardship activities for a specified child.

Route to handle parent adopt site for child:
`POST api/v1/protected/sites/:site_id/parent_adopt`

Route to handle parent record stewardship for child:
`POST api/v1/protected/sites/:site_id/parent_record_stewardship`

Created additional helper methods (`checkParent`, `isParent`) for the `ProtectedSiteProcessor` for determining whether a user is the parent of a given child.

[ClickUp Ticket](https://app.clickup.com/t/29xd1x4)