### PR TITLE
Change stewardship activity date field timezone from UTC to EST

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RecordStewardshipRequest extends ApiDto {
-  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy", timezone="America/New_York")
   private java.sql.Date date;
 
   private boolean watered;


### PR DESCRIPTION
When parsing and saving stewardship activity dates, change the timezone from the default (UTC) timezone to Boston time (GMT-4).