### PR TITLE
Add Edit Stewardship Route

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -31,7 +31,7 @@ public interface IProtectedSiteProcessor {
   void recordStewardship(
       JWTData userData, int siteId, RecordStewardshipRequest recordStewardshipRequest);
 
-  /** Edits the given stewardship activity */
+  /** Edit features of the given stewardship activity */
   void editStewardship(
       JWTData userData, int activityId, EditStewardshipRequest editStewardshipRequest);
 

--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -5,6 +5,7 @@ import com.codeforcommunity.dto.site.AddSiteRequest;
 import com.codeforcommunity.dto.site.AddSitesRequest;
 import com.codeforcommunity.dto.site.AdoptedSitesResponse;
 import com.codeforcommunity.dto.site.EditSiteRequest;
+import com.codeforcommunity.dto.site.EditStewardshipRequest;
 import com.codeforcommunity.dto.site.NameSiteEntryRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
@@ -29,6 +30,10 @@ public interface IProtectedSiteProcessor {
   /** Records a new stewardship activity in the stewardship table linked to the given site */
   void recordStewardship(
       JWTData userData, int siteId, RecordStewardshipRequest recordStewardshipRequest);
+
+  /** Edits the given stewardship activity */
+  void editStewardship(
+      JWTData userData, int activityId, EditStewardshipRequest editStewardshipRequest);
 
   /** Creates a new site with entries in the sites and siteEntries tables */
   void addSite(JWTData userData, AddSiteRequest addSiteRequest);

--- a/api/src/main/java/com/codeforcommunity/dto/site/EditStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/EditStewardshipRequest.java
@@ -1,0 +1,43 @@
+package com.codeforcommunity.dto.site;
+
+import com.codeforcommunity.exceptions.HandledException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EditStewardshipRequest extends RecordStewardshipRequest {
+
+  private Integer activityId;
+
+  public EditStewardshipRequest(
+      java.sql.Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded, Integer activityId) {
+    super(date, watered, mulched, cleaned, weeded);
+    this.activityId = activityId;
+  }
+
+  public Integer getActivityId() {
+    return activityId;
+  }
+
+  public void setActivityId(Integer activityId) {
+    this.activityId = activityId;
+  }
+
+  @Override
+  public List<String> validateFields(String fieldPrefix) throws HandledException {
+    String fieldName = fieldPrefix + "edit_stewardship_request.";
+    List<String> fields = new ArrayList<>();
+
+    if (getDate() == null) {
+      fields.add(fieldName + "date");
+    }
+    if (!(getWatered() || getMulched() || getCleaned() || getWeeded())) {
+      fields.add(fieldName + "activities");
+    }
+    if (activityId == null) {
+      fields.add(fieldName + "activityId");
+    }
+
+    return fields;
+  }
+}

--- a/api/src/main/java/com/codeforcommunity/dto/site/EditStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/EditStewardshipRequest.java
@@ -7,20 +7,9 @@ import java.util.List;
 
 public class EditStewardshipRequest extends RecordStewardshipRequest {
 
-  private Integer activityId;
-
   public EditStewardshipRequest(
       java.sql.Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded, Integer activityId) {
     super(date, watered, mulched, cleaned, weeded);
-    this.activityId = activityId;
-  }
-
-  public Integer getActivityId() {
-    return activityId;
-  }
-
-  public void setActivityId(Integer activityId) {
-    this.activityId = activityId;
   }
 
   @Override
@@ -33,9 +22,6 @@ public class EditStewardshipRequest extends RecordStewardshipRequest {
     }
     if (!(getWatered() || getMulched() || getCleaned() || getWeeded())) {
       fields.add(fieldName + "activities");
-    }
-    if (activityId == null) {
-      fields.add(fieldName + "activityId");
     }
 
     return fields;

--- a/api/src/main/java/com/codeforcommunity/dto/site/EditStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/EditStewardshipRequest.java
@@ -1,71 +1,17 @@
 package com.codeforcommunity.dto.site;
 
-import com.codeforcommunity.dto.ApiDto;
 import com.codeforcommunity.exceptions.HandledException;
-import com.fasterxml.jackson.annotation.JsonFormat;
-
 import java.util.ArrayList;
 import java.util.List;
 
-public class EditStewardshipRequest extends ApiDto {
-  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy", timezone = "America/New_York")
-  private java.sql.Date date;
-
-  private boolean watered;
-  private boolean mulched;
-  private boolean cleaned;
-  private boolean weeded;
+public class EditStewardshipRequest extends RecordStewardshipRequest {
 
   public EditStewardshipRequest(
       java.sql.Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded) {
-    this.date = date;
-    this.watered = watered;
-    this.mulched = mulched;
-    this.cleaned = cleaned;
-    this.weeded = weeded;
+    super(date, watered, mulched, cleaned, weeded);
   }
 
   private EditStewardshipRequest() {}
-
-  public java.sql.Date getDate() {
-    return date;
-  }
-
-  public void setDate(java.sql.Date date) {
-    this.date = date;
-  }
-
-  public boolean getWatered() {
-    return watered;
-  }
-
-  public void setWatered(boolean watered) {
-    this.watered = watered;
-  }
-
-  public boolean getMulched() {
-    return mulched;
-  }
-
-  public void setMulched(boolean mulched) {
-    this.mulched = mulched;
-  }
-
-  public boolean getCleaned() {
-    return cleaned;
-  }
-
-  public void setCleaned(boolean cleaned) {
-    this.cleaned = cleaned;
-  }
-
-  public boolean getWeeded() {
-    return weeded;
-  }
-
-  public void setWeeded(boolean weeded) {
-    this.weeded = weeded;
-  }
 
   @Override
   public List<String> validateFields(String fieldPrefix) throws HandledException {
@@ -75,7 +21,7 @@ public class EditStewardshipRequest extends ApiDto {
     if (getDate() == null) {
       fields.add(fieldName + "date");
     }
-    if (!(getWatered() || getMulched() || getCleaned() || getWeeded())) {
+    if (!(watered || mulched || cleaned || weeded)) {
       fields.add(fieldName + "activities");
     }
 

--- a/api/src/main/java/com/codeforcommunity/dto/site/EditStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/EditStewardshipRequest.java
@@ -1,13 +1,14 @@
 package com.codeforcommunity.dto.site;
 
 import com.codeforcommunity.exceptions.HandledException;
+import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
 
 public class EditStewardshipRequest extends RecordStewardshipRequest {
 
   public EditStewardshipRequest(
-      java.sql.Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded) {
+      Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded) {
     super(date, watered, mulched, cleaned, weeded);
   }
 
@@ -15,16 +16,6 @@ public class EditStewardshipRequest extends RecordStewardshipRequest {
 
   @Override
   public List<String> validateFields(String fieldPrefix) throws HandledException {
-    String fieldName = fieldPrefix + "edit_stewardship_request.";
-    List<String> fields = new ArrayList<>();
-
-    if (getDate() == null) {
-      fields.add(fieldName + "date");
-    }
-    if (!(watered || mulched || cleaned || weeded)) {
-      fields.add(fieldName + "activities");
-    }
-
-    return fields;
+    return validateStewardshipFields(fieldPrefix + "edit_stewardship_request.");
   }
 }

--- a/api/src/main/java/com/codeforcommunity/dto/site/EditStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/EditStewardshipRequest.java
@@ -2,7 +2,6 @@ package com.codeforcommunity.dto.site;
 
 import com.codeforcommunity.exceptions.HandledException;
 import java.sql.Date;
-import java.util.ArrayList;
 import java.util.List;
 
 public class EditStewardshipRequest extends RecordStewardshipRequest {

--- a/api/src/main/java/com/codeforcommunity/dto/site/EditStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/EditStewardshipRequest.java
@@ -1,15 +1,70 @@
 package com.codeforcommunity.dto.site;
 
+import com.codeforcommunity.dto.ApiDto;
 import com.codeforcommunity.exceptions.HandledException;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class EditStewardshipRequest extends RecordStewardshipRequest {
+public class EditStewardshipRequest extends ApiDto {
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy", timezone = "America/New_York")
+  private java.sql.Date date;
+
+  private boolean watered;
+  private boolean mulched;
+  private boolean cleaned;
+  private boolean weeded;
 
   public EditStewardshipRequest(
-      java.sql.Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded, Integer activityId) {
-    super(date, watered, mulched, cleaned, weeded);
+      java.sql.Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded) {
+    this.date = date;
+    this.watered = watered;
+    this.mulched = mulched;
+    this.cleaned = cleaned;
+    this.weeded = weeded;
+  }
+
+  private EditStewardshipRequest() {}
+
+  public java.sql.Date getDate() {
+    return date;
+  }
+
+  public void setDate(java.sql.Date date) {
+    this.date = date;
+  }
+
+  public boolean getWatered() {
+    return watered;
+  }
+
+  public void setWatered(boolean watered) {
+    this.watered = watered;
+  }
+
+  public boolean getMulched() {
+    return mulched;
+  }
+
+  public void setMulched(boolean mulched) {
+    this.mulched = mulched;
+  }
+
+  public boolean getCleaned() {
+    return cleaned;
+  }
+
+  public void setCleaned(boolean cleaned) {
+    this.cleaned = cleaned;
+  }
+
+  public boolean getWeeded() {
+    return weeded;
+  }
+
+  public void setWeeded(boolean weeded) {
+    this.weeded = weeded;
   }
 
   @Override

--- a/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
@@ -3,12 +3,13 @@ package com.codeforcommunity.dto.site;
 import com.codeforcommunity.dto.ApiDto;
 import com.codeforcommunity.exceptions.HandledException;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
 
 public class RecordStewardshipRequest extends ApiDto {
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy", timezone="America/New_York")
-  private java.sql.Date date;
+  protected Date date;
 
   protected boolean watered;
   protected boolean mulched;
@@ -16,7 +17,7 @@ public class RecordStewardshipRequest extends ApiDto {
   protected boolean weeded;
 
   public RecordStewardshipRequest(
-      java.sql.Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded) {
+      Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded) {
     this.date = date;
     this.watered = watered;
     this.mulched = mulched;
@@ -66,9 +67,7 @@ public class RecordStewardshipRequest extends ApiDto {
     this.weeded = weeded;
   }
 
-  @Override
-  public List<String> validateFields(String fieldPrefix) throws HandledException {
-    String fieldName = fieldPrefix + "record_stewardship_request.";
+  protected List<String> validateStewardshipFields(String fieldName) {
     List<String> fields = new ArrayList<>();
 
     if (date == null) {
@@ -79,5 +78,10 @@ public class RecordStewardshipRequest extends ApiDto {
     }
 
     return fields;
+  }
+
+  @Override
+  public List<String> validateFields(String fieldPrefix) throws HandledException {
+    return validateStewardshipFields(fieldPrefix + "record_stewardship_request.");
   }
 }

--- a/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RecordStewardshipRequest extends ApiDto {
-  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy", timezone = "America/New_York")
   private java.sql.Date date;
 
   private boolean watered;

--- a/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
@@ -10,10 +10,10 @@ public class RecordStewardshipRequest extends ApiDto {
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy", timezone = "America/New_York")
   private java.sql.Date date;
 
-  private boolean watered;
-  private boolean mulched;
-  private boolean cleaned;
-  private boolean weeded;
+  protected boolean watered;
+  protected boolean mulched;
+  protected boolean cleaned;
+  protected boolean weeded;
 
   public RecordStewardshipRequest(
       java.sql.Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded) {
@@ -24,7 +24,7 @@ public class RecordStewardshipRequest extends ApiDto {
     this.weeded = weeded;
   }
 
-  private RecordStewardshipRequest() {}
+  protected RecordStewardshipRequest() {}
 
   public java.sql.Date getDate() {
     return date;

--- a/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/RecordStewardshipRequest.java
@@ -10,10 +10,10 @@ public class RecordStewardshipRequest extends ApiDto {
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy", timezone="America/New_York")
   private java.sql.Date date;
 
-  private boolean watered;
-  private boolean mulched;
-  private boolean cleaned;
-  private boolean weeded;
+  protected boolean watered;
+  protected boolean mulched;
+  protected boolean cleaned;
+  protected boolean weeded;
 
   public RecordStewardshipRequest(
       java.sql.Date date, boolean watered, boolean mulched, boolean cleaned, boolean weeded) {
@@ -24,7 +24,7 @@ public class RecordStewardshipRequest extends ApiDto {
     this.weeded = weeded;
   }
 
-  private RecordStewardshipRequest() {}
+  protected RecordStewardshipRequest() {}
 
   public java.sql.Date getDate() {
     return date;

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -8,6 +8,7 @@ import com.codeforcommunity.dto.site.AddSiteRequest;
 import com.codeforcommunity.dto.site.AddSitesRequest;
 import com.codeforcommunity.dto.site.AdoptedSitesResponse;
 import com.codeforcommunity.dto.site.EditSiteRequest;
+import com.codeforcommunity.dto.site.EditStewardshipRequest;
 import com.codeforcommunity.dto.site.NameSiteEntryRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
@@ -148,6 +149,21 @@ public class ProtectedSiteRouter implements IRouter {
     int activityId = RestFunctions.getRequestParameterAsInt(ctx.request(), "activity_id");
 
     processor.deleteStewardship(userData, activityId);
+
+    end(ctx.response(), 200);
+  }
+
+  private void registerEditStewardship(Router router) {
+    Route editStewardshipRoute = router.post("/edit_stewardship/:activity_id");
+    editStewardshipRoute.handler(this::handleEditStewardshipRoute);
+  }
+
+  private void handleEditStewardshipRoute(RoutingContext ctx) {
+    JWTData userData = ctx.get("jwt_data");
+    int activityId = RestFunctions.getRequestParameterAsInt(ctx.request(), "activity_id");
+    EditStewardshipRequest editStewardshipRequest = RestFunctions.getJsonBodyAsClass(ctx, EditStewardshipRequest.class);
+
+    processor.editStewardship(userData, activityId, editStewardshipRequest);
 
     end(ctx.response(), 200);
   }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -45,6 +45,7 @@ public class ProtectedSiteRouter implements IRouter {
     registerEditSite(router);
     registerAddSites(router);
     registerDeleteStewardship(router);
+    registerEditStewardship(router);
     registerNameSiteEntry(router);
 
     return router;

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -376,7 +376,6 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
           "User needs to be an admin or the activity's author to edit the record.");
     }
 
-    activity.setId(activityId);
     activity.setPerformedOn(editStewardshipRequest.getDate());
     activity.setWatered(editStewardshipRequest.getWatered());
     activity.setMulched(editStewardshipRequest.getMulched());

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -114,6 +114,7 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
 
   private boolean isAdminOrOwner(JWTData userData, Integer ownerId) {
     return isAdmin(userData.getPrivilegeLevel()) || userData.getUserId().equals(ownerId);
+  }
 
   /**
    * Throws an exception if the user account is not the parent of the other user account.

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -108,6 +108,10 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
     return level.equals(PrivilegeLevel.ADMIN) || level.equals(PrivilegeLevel.SUPER_ADMIN);
   }
 
+  private boolean isAdminOrOwner(JWTData userData, Integer ownerId) {
+    return isAdmin(userData.getPrivilegeLevel()) || userData.getUserId().equals(ownerId);
+  }
+
   @Override
   public void adoptSite(JWTData userData, int siteId, Date dateAdopted) {
     checkSiteExists(siteId);
@@ -369,9 +373,7 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
     StewardshipRecord activity =
         db.selectFrom(STEWARDSHIP).where(STEWARDSHIP.ID.eq(activityId)).fetchOne();
 
-    if (!(activity.getUserId().equals(userData.getUserId())
-        || userData.getPrivilegeLevel().equals(PrivilegeLevel.SUPER_ADMIN)
-        || userData.getPrivilegeLevel().equals(PrivilegeLevel.ADMIN))) {
+    if (!isAdminOrOwner(userData, activity.getUserId())) {
       throw new AuthException(
           "User needs to be an admin or the activity's author to edit the record.");
     }
@@ -390,9 +392,7 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
     StewardshipRecord activity =
         db.selectFrom(STEWARDSHIP).where(STEWARDSHIP.ID.eq(activityId)).fetchOne();
 
-    if (!(activity.getUserId().equals(userData.getUserId())
-        || userData.getPrivilegeLevel().equals(PrivilegeLevel.SUPER_ADMIN)
-        || userData.getPrivilegeLevel().equals(PrivilegeLevel.ADMIN))) {
+    if (!isAdminOrOwner(userData, activity.getUserId())) {
       throw new AuthException(
           "User needs to be an admin or the activity's author to delete the record.");
     }


### PR DESCRIPTION
# Why

[ClickUp ticket](https://app.clickup.com/t/3ucv22f)

Add route to allow admins and tree site owners to edit existing stewardship activities

Route: ```POST api/v1/protected/sites/edit_stewardship/:site_id```

# This PR

- Add new class EditStewardShipRequest 
- Update ProtectedSiteRouter, ProtectedSiteProcessorImpl to handle edit stewardship requests

# Verification steps

- Request to edit existing record as admin - database correctly reflects changes
- Request to edit existing record as non-admin owner - database correctly reflects changes
- Request to edit nonexistent record - returns proper error status + message
- Request to edit existing record as non-admin/non-owner - returns proper error status + message
- Request to edit existing record with malformed body - returns proper error status + message 