### PR TITLE
Update get site and name site entry routes

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/site/GetSiteResponse.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/GetSiteResponse.java
@@ -31,8 +31,8 @@ public class GetSiteResponse {
     this.city = city;
     this.zip = zip;
     this.address = address;
-    this.entries = entries;
     this.neighborhoodId = neighborhoodId;
+    this.entries = entries;
   }
 
   public Integer getSiteId() {
@@ -63,7 +63,7 @@ public class GetSiteResponse {
     return address;
   }
 
-  public Integer getNeighborhood() {
+  public Integer getNeighborhoodId() {
     return neighborhoodId;
   }
 

--- a/api/src/main/java/com/codeforcommunity/dto/site/SiteEntry.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/SiteEntry.java
@@ -53,7 +53,7 @@ public class SiteEntry {
   private final String melneaCassTrees;
   private final Integer mcbNumber;
   private final String treeDedicatedTo;
-  private final Date plantingData;
+  private final Date plantingDate;
   private final String treeName;
   private final String adopter;
 
@@ -102,7 +102,7 @@ public class SiteEntry {
       String melneaCassTrees,
       Integer mcbNumber,
       String treeDedicatedTo,
-      Date plantingData,
+      Date plantingDate,
       String treeName,
       String adopter) {
     this.id = id;
@@ -149,7 +149,7 @@ public class SiteEntry {
     this.melneaCassTrees = melneaCassTrees;
     this.mcbNumber = mcbNumber;
     this.treeDedicatedTo = treeDedicatedTo;
-    this.plantingData = plantingData;
+    this.plantingDate = plantingDate;
     this.treeName = treeName;
     this.adopter = adopter;
   }
@@ -330,8 +330,8 @@ public class SiteEntry {
     return treeDedicatedTo;
   }
 
-  public Date getPlantingData() {
-    return plantingData;
+  public Date getPlantingDate() {
+    return plantingDate;
   }
 
   public String getTreeName() {

--- a/api/src/main/java/com/codeforcommunity/dto/site/SiteEntry.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/SiteEntry.java
@@ -1,6 +1,8 @@
 package com.codeforcommunity.dto.site;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.sql.Date;
 import java.sql.Timestamp;
 
 public class SiteEntry {
@@ -48,6 +50,11 @@ public class SiteEntry {
   private final Boolean stump;
   private final String treeNotes;
   private final String siteNotes;
+  private final String melneaCassTrees;
+  private final Integer mcbNumber;
+  private final String treeDedicatedTo;
+  private final Date plantingData;
+  private final String treeName;
   private final String adopter;
 
   public SiteEntry(
@@ -92,6 +99,11 @@ public class SiteEntry {
       Boolean stump,
       String treeNotes,
       String siteNotes,
+      String melneaCassTrees,
+      Integer mcbNumber,
+      String treeDedicatedTo,
+      Date plantingData,
+      String treeName,
       String adopter) {
     this.id = id;
     this.username = username;
@@ -134,6 +146,11 @@ public class SiteEntry {
     this.stump = stump;
     this.treeNotes = treeNotes;
     this.siteNotes = siteNotes;
+    this.melneaCassTrees = melneaCassTrees;
+    this.mcbNumber = mcbNumber;
+    this.treeDedicatedTo = treeDedicatedTo;
+    this.plantingData = plantingData;
+    this.treeName = treeName;
     this.adopter = adopter;
   }
 
@@ -299,6 +316,26 @@ public class SiteEntry {
 
   public String getSiteNotes() {
     return siteNotes;
+  }
+
+  public String getMelneaCassTrees() {
+    return melneaCassTrees;
+  }
+
+  public Integer getMcbNumber() {
+    return mcbNumber;
+  }
+
+  public String getTreeDedicatedTo() {
+    return treeDedicatedTo;
+  }
+
+  public Date getPlantingData() {
+    return plantingData;
+  }
+
+  public String getTreeName() {
+    return treeName;
   }
 
   public String getAdopter() {

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -387,7 +387,7 @@ public class ProtectedSiteProcessorImpl implements IProtectedSiteProcessor {
 
     SiteEntriesRecord siteEntry = db.selectFrom(SITE_ENTRIES)
         .where(SITE_ENTRIES.SITE_ID.eq(siteId))
-        .orderBy(SITE_ENTRIES.UPDATED_AT)
+        .orderBy(SITE_ENTRIES.UPDATED_AT.desc())
         .limit(1)
         .fetchOne();
 

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -493,9 +493,7 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
   public void nameSiteEntry(
       JWTData userData, int siteId, NameSiteEntryRequest nameSiteEntryRequest) {
     checkSiteExists(siteId);
-    if (!isAlreadyAdoptedByUser(userData.getUserId(), siteId)) {
-      throw new AuthException("User is not the site's adopter.");
-    }
+    checkAdminOrSiteAdopter(userData, siteId);
 
     SiteEntriesRecord siteEntry = db.selectFrom(SITE_ENTRIES)
         .where(SITE_ENTRIES.SITE_ID.eq(siteId))

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -507,10 +507,10 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
 
     if (nameSiteEntryRequest.getName().isEmpty()) {
       siteEntry.setTreeName(null);
-    }
-    else {
+    } else {
       siteEntry.setTreeName(nameSiteEntryRequest.getName());
     }
+
     siteEntry.store();
   }
 

--- a/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
@@ -118,6 +118,11 @@ public class SiteProcessorImpl implements ISiteProcessor {
                   record.getStump(),
                   record.getTreeNotes(),
                   record.getSiteNotes(),
+                  record.getMelneaCassTrees(),
+                  record.getMcbNumber(),
+                  record.getTreeDedicatedTo(),
+                  record.getPlantingDate(),
+                  record.getTreeName(),
                   adopter);
 
           siteEntries.add(siteEntry);


### PR DESCRIPTION
Modify the get site route so that it also returns the tree name for each site entry.

Modify the name site entry route so that passing in an empty string deletes its name (i.e. sets is to `null`).