### PR TITLE
Make email equals check case insensitive

### DIFF
--- a/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
+++ b/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
@@ -53,7 +53,7 @@ public class AuthDatabaseOperations {
   public JWTData getUserJWTData(String email) {
     Optional<Users> maybeUser =
         Optional.ofNullable(
-            db.selectFrom(USERS).where(USERS.EMAIL.eq(email)).fetchOneInto(Users.class));
+            db.selectFrom(USERS).where(USERS.EMAIL.equalIgnoreCase(email)).fetchOneInto(Users.class));
 
     if (maybeUser.isPresent()) {
       Users user = maybeUser.get();
@@ -88,7 +88,7 @@ public class AuthDatabaseOperations {
   public boolean isValidLogin(String email, String pass) {
     Optional<Users> maybeUser =
         Optional.ofNullable(
-            db.selectFrom(USERS).where(USERS.EMAIL.eq(email)).fetchOneInto(Users.class));
+            db.selectFrom(USERS).where(USERS.EMAIL.equalIgnoreCase(email)).fetchOneInto(Users.class));
 
     return maybeUser
         .filter(user -> Passwords.isExpectedPassword(pass, user.getPasswordHash()))
@@ -108,7 +108,7 @@ public class AuthDatabaseOperations {
       throw new UsernameAlreadyInUseException(username);
     }
 
-    boolean emailUsed = db.fetchExists(USERS, USERS.EMAIL.eq(email));
+    boolean emailUsed = db.fetchExists(USERS, USERS.EMAIL.equalIgnoreCase(email));
     if (emailUsed) {
       throw new EmailAlreadyInUseException(email);
     }


### PR DESCRIPTION
ClickUp ticket: https://app.clickup.com/t/47u12vb

Change checking for email equality to always be case insensitive.

Tested that the following affected routes still work:

* Log in
* Sign up
* Request password reset
* Change email
* Change privilege level
* Create child account
