### PR TITLE
Add import routes for tree species and benefits and add sql migrations

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IImportProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IImportProcessor.java
@@ -5,6 +5,8 @@ import com.codeforcommunity.dto.imports.ImportBlocksRequest;
 import com.codeforcommunity.dto.imports.ImportNeighborhoodsRequest;
 import com.codeforcommunity.dto.imports.ImportReservationsRequest;
 import com.codeforcommunity.dto.imports.ImportSitesRequest;
+import com.codeforcommunity.dto.imports.ImportTreeBenefitsRequest;
+import com.codeforcommunity.dto.imports.ImportTreeSpeciesRequest;
 
 public interface IImportProcessor {
   void importBlocks(JWTData userData, ImportBlocksRequest importBlocksRequest);
@@ -14,4 +16,8 @@ public interface IImportProcessor {
   void importReservations(JWTData userData, ImportReservationsRequest importReservationsRequest);
 
   void importSites(JWTData userData, ImportSitesRequest importSitesRequest);
+
+  void importTreeSpecies(JWTData userData, ImportTreeSpeciesRequest importTreeSpeciesRequest);
+
+  void importTreeBenefits(JWTData userData, ImportTreeBenefitsRequest importTreeBenefitsRequest);
 }

--- a/api/src/main/java/com/codeforcommunity/dto/imports/ImportTreeBenefitsRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/imports/ImportTreeBenefitsRequest.java
@@ -32,7 +32,7 @@ public class ImportTreeBenefitsRequest extends ApiDto {
     }
 
     return treeBenefits.stream()
-        .flatMap(ni -> ni.validateFields(newFieldPrefix).stream())
+        .flatMap(treeBenefitImport -> treeBenefitImport.validateFields(newFieldPrefix).stream())
         .collect(Collectors.toList());
   }
 }

--- a/api/src/main/java/com/codeforcommunity/dto/imports/ImportTreeBenefitsRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/imports/ImportTreeBenefitsRequest.java
@@ -1,0 +1,38 @@
+package com.codeforcommunity.dto.imports;
+
+import com.codeforcommunity.dto.ApiDto;
+import com.codeforcommunity.exceptions.HandledException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ImportTreeBenefitsRequest extends ApiDto {
+  private List<TreeBenefitImport> treeBenefits;
+
+  public ImportTreeBenefitsRequest(List<TreeBenefitImport> treeBenefits) {
+    this.treeBenefits = treeBenefits;
+  }
+
+  private ImportTreeBenefitsRequest() {}
+
+  public List<TreeBenefitImport> getTreeBenefits() {
+    return treeBenefits;
+  }
+
+  public void setTreeBenefits(List<TreeBenefitImport> treeBenefits) {
+    this.treeBenefits = treeBenefits;
+  }
+
+  @Override
+  public List<String> validateFields(String fieldPrefix) throws HandledException {
+    String newFieldPrefix = fieldPrefix + "importTreeBenefitsRequest.";
+
+    if (treeBenefits == null) {
+      return Collections.singletonList(newFieldPrefix + "treeBenefits");
+    }
+
+    return treeBenefits.stream()
+        .flatMap(ni -> ni.validateFields(newFieldPrefix).stream())
+        .collect(Collectors.toList());
+  }
+}

--- a/api/src/main/java/com/codeforcommunity/dto/imports/ImportTreeSpeciesRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/imports/ImportTreeSpeciesRequest.java
@@ -32,7 +32,7 @@ public class ImportTreeSpeciesRequest extends ApiDto {
     }
 
     return treeSpecies.stream()
-        .flatMap(ni -> ni.validateFields(newFieldPrefix).stream())
+        .flatMap(treeSpeciesImport -> treeSpeciesImport.validateFields(newFieldPrefix).stream())
         .collect(Collectors.toList());
   }
 }

--- a/api/src/main/java/com/codeforcommunity/dto/imports/ImportTreeSpeciesRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/imports/ImportTreeSpeciesRequest.java
@@ -1,0 +1,38 @@
+package com.codeforcommunity.dto.imports;
+
+import com.codeforcommunity.dto.ApiDto;
+import com.codeforcommunity.exceptions.HandledException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ImportTreeSpeciesRequest extends ApiDto {
+  private List<TreeSpeciesImport> treeSpecies;
+
+  public ImportTreeSpeciesRequest(List<TreeSpeciesImport> treeSpecies) {
+    this.treeSpecies = treeSpecies;
+  }
+
+  private ImportTreeSpeciesRequest() {}
+
+  public List<TreeSpeciesImport> getTreeSpecies() {
+    return treeSpecies;
+  }
+
+  public void setTreeSpecies(List<TreeSpeciesImport> treeSpecies) {
+    this.treeSpecies = treeSpecies;
+  }
+
+  @Override
+  public List<String> validateFields(String fieldPrefix) throws HandledException {
+    String newFieldPrefix = fieldPrefix + "importTreeSpeciesRequest.";
+
+    if (treeSpecies == null) {
+      return Collections.singletonList(newFieldPrefix + "treeSpecies");
+    }
+
+    return treeSpecies.stream()
+        .flatMap(ni -> ni.validateFields(newFieldPrefix).stream())
+        .collect(Collectors.toList());
+  }
+}

--- a/api/src/main/java/com/codeforcommunity/dto/imports/TreeBenefitImport.java
+++ b/api/src/main/java/com/codeforcommunity/dto/imports/TreeBenefitImport.java
@@ -1,0 +1,247 @@
+package com.codeforcommunity.dto.imports;
+
+import com.codeforcommunity.dto.ApiDto;
+import com.codeforcommunity.exceptions.HandledException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TreeBenefitImport extends ApiDto {
+  private String speciesCode;
+  private Double diameter;
+  private Double aqNoxAvoided;
+  private Double aqNoxDep;
+  private Double aqOzoneDep;
+  private Double aqPm10Avoided;
+  private Double aqPm10Dep;
+  private Double aqSoxAvoided;
+  private Double aqSoxDep;
+  private Double aqVocAvoided;
+  private Double co2Avoided;
+  private Double co2Sequestered;
+  private Double co2Storage;
+  private Double electricity;
+  private Double hydroInterception;
+  private Double naturalGas;
+
+  public TreeBenefitImport(
+      String speciesCode,
+      Double diameter,
+      Double aqNoxAvoided,
+      Double aqNoxDep,
+      Double aqOzoneDep,
+      Double aqPm10Avoided,
+      Double aqPm10Dep,
+      Double aqSoxAvoided,
+      Double aqSoxDep,
+      Double aqVocAvoided,
+      Double co2Avoided,
+      Double co2Sequestered,
+      Double co2Storage,
+      Double electricity,
+      Double hydroInterception,
+      Double naturalGas) {
+    this.speciesCode = speciesCode;
+    this.diameter = diameter;
+    this.aqNoxAvoided = aqNoxAvoided;
+    this.aqNoxDep = aqNoxDep;
+    this.aqOzoneDep = aqOzoneDep;
+    this.aqPm10Avoided = aqPm10Avoided;
+    this.aqPm10Dep = aqPm10Dep;
+    this.aqSoxAvoided = aqSoxAvoided;
+    this.aqSoxDep = aqSoxDep;
+    this.aqVocAvoided = aqVocAvoided;
+    this.co2Avoided = co2Avoided;
+    this.co2Sequestered = co2Sequestered;
+    this.co2Storage = co2Storage;
+    this.electricity = electricity;
+    this.hydroInterception = hydroInterception;
+    this.naturalGas = naturalGas;
+  }
+
+  private TreeBenefitImport() {}
+
+  public String getSpeciesCode() {
+    return speciesCode;
+  }
+
+  public void setSpeciesCode(String speciesCode) {
+    this.speciesCode = speciesCode;
+  }
+
+  public Double getDiameter() {
+    return diameter;
+  }
+
+  public void setDiameter(Double diameter) {
+    this.diameter = diameter;
+  }
+
+  public Double getAqNoxAvoided() {
+    return aqNoxAvoided;
+  }
+
+  public void setAqNoxAvoided(Double aqNoxAvoided) {
+    this.aqNoxAvoided = aqNoxAvoided;
+  }
+
+  public Double getAqNoxDep() {
+    return aqNoxDep;
+  }
+
+  public void setAqNoxDep(Double aqNoxDep) {
+    this.aqNoxDep = aqNoxDep;
+  }
+
+  public Double getAqOzoneDep() {
+    return aqOzoneDep;
+  }
+
+  public void setAqOzoneDep(Double aqOzoneDep) {
+    this.aqOzoneDep = aqOzoneDep;
+  }
+
+  public Double getAqPm10Avoided() {
+    return aqPm10Avoided;
+  }
+
+  public void setAqPm10Avoided(Double aqPm10Avoided) {
+    this.aqPm10Avoided = aqPm10Avoided;
+  }
+
+  public Double getAqPm10Dep() {
+    return aqPm10Dep;
+  }
+
+  public void setAqPm10Dep(Double aqPm10Dep) {
+    this.aqPm10Dep = aqPm10Dep;
+  }
+
+  public Double getAqSoxAvoided() {
+    return aqSoxAvoided;
+  }
+
+  public void setAqSoxAvoided(Double aqSoxAvoided) {
+    this.aqSoxAvoided = aqSoxAvoided;
+  }
+
+  public Double getAqSoxDep() {
+    return aqSoxDep;
+  }
+
+  public void setAqSoxDep(Double aqSoxDep) {
+    this.aqSoxDep = aqSoxDep;
+  }
+
+  public Double getAqVocAvoided() {
+    return aqVocAvoided;
+  }
+
+  public void setAqVocAvoided(Double aqVocAvoided) {
+    this.aqVocAvoided = aqVocAvoided;
+  }
+
+  public Double getCo2Avoided() {
+    return co2Avoided;
+  }
+
+  public void setCo2Avoided(Double co2Avoided) {
+    this.co2Avoided = co2Avoided;
+  }
+
+  public Double getCo2Sequestered() {
+    return co2Sequestered;
+  }
+
+  public void setCo2Sequestered(Double co2Sequestered) {
+    this.co2Sequestered = co2Sequestered;
+  }
+
+  public Double getCo2Storage() {
+    return co2Storage;
+  }
+
+  public void setCo2Storage(Double co2Storage) {
+    this.co2Storage = co2Storage;
+  }
+
+  public Double getElectricity() {
+    return electricity;
+  }
+
+  public void setElectricity(Double electricity) {
+    this.electricity = electricity;
+  }
+
+  public Double getHydroInterception() {
+    return hydroInterception;
+  }
+
+  public void setHydroInterception(Double hydroInterception) {
+    this.hydroInterception = hydroInterception;
+  }
+
+  public Double getNaturalGas() {
+    return naturalGas;
+  }
+
+  public void setNaturalGas(Double naturalGas) {
+    this.naturalGas = naturalGas;
+  }
+
+  @Override
+  public List<String> validateFields(String fieldPrefix) throws HandledException {
+    String fieldName = fieldPrefix + "tree_benefit.";
+    List<String> fields = new ArrayList<>();
+
+    if (speciesCode == null || isEmpty(speciesCode)) {
+      fields.add(fieldName + "speciesCode");
+    }
+    if (diameter == null || diameter < 0) {
+      fields.add(fieldName + "diameter");
+    }
+    if (aqNoxAvoided == null || aqNoxAvoided < 0) {
+      fields.add(fieldName + "aqNoxAvoided");
+    }
+    if (aqNoxDep == null || aqNoxDep < 0) {
+      fields.add(fieldName + "aqNoxDep");
+    }
+    if (aqOzoneDep == null || aqOzoneDep < 0) {
+      fields.add(fieldName + "aqOzoneDep");
+    }
+    if (aqPm10Avoided == null || aqPm10Avoided < 0) {
+      fields.add(fieldName + "aqPm10Avoided");
+    }
+    if (aqPm10Dep == null || aqPm10Dep < 0) {
+      fields.add(fieldName + "aqPm10Dep");
+    }
+    if (aqSoxAvoided == null || aqSoxAvoided < 0) {
+      fields.add(fieldName + "aqSoxAvoided");
+    }
+    if (aqSoxDep == null || aqSoxDep < 0) {
+      fields.add(fieldName + "aqSoxDep");
+    }
+    if (aqVocAvoided == null || aqVocAvoided < 0) {
+      fields.add(fieldName + "aqVocAvoided");
+    }
+    if (co2Avoided == null || co2Avoided < 0) {
+      fields.add(fieldName + "co2Avoided");
+    }
+    if (co2Sequestered == null || co2Sequestered < 0) {
+      fields.add(fieldName + "co2Sequestered");
+    }
+    if (co2Storage == null || co2Storage < 0) {
+      fields.add(fieldName + "co2Storage");
+    }
+    if (electricity == null || electricity < 0) {
+      fields.add(fieldName + "electricity");
+    }
+    if (hydroInterception == null || hydroInterception < 0) {
+      fields.add(fieldName + "hydroInterception");
+    }
+    if (naturalGas == null || naturalGas < 0) {
+      fields.add(fieldName + "naturalGas");
+    }
+
+    return fields;
+  }
+}

--- a/api/src/main/java/com/codeforcommunity/dto/imports/TreeSpeciesImport.java
+++ b/api/src/main/java/com/codeforcommunity/dto/imports/TreeSpeciesImport.java
@@ -1,0 +1,75 @@
+package com.codeforcommunity.dto.imports;
+
+import com.codeforcommunity.dto.ApiDto;
+import com.codeforcommunity.exceptions.HandledException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TreeSpeciesImport extends ApiDto {
+  private String genus;
+  private String species;
+  private String commonName;
+  private String speciesCode;
+
+  public TreeSpeciesImport(String genus, String species, String commonName, String speciesCode) {
+    this.genus = genus;
+    this.species = species;
+    this.commonName = commonName;
+    this.speciesCode = speciesCode;
+  }
+
+  private TreeSpeciesImport() {}
+
+  public String getGenus() {
+    return genus;
+  }
+
+  public void setGenus(String genus) {
+    this.genus = genus;
+  }
+
+  public String getSpecies() {
+    return species;
+  }
+
+  public void setSpecies(String species) {
+    this.species = species;
+  }
+
+  public String getCommonName() {
+    return commonName;
+  }
+
+  public void setCommonName(String commonName) {
+    this.commonName = commonName;
+  }
+
+  public String getSpeciesCode() {
+    return speciesCode;
+  }
+
+  public void setSpeciesCode(String speciesCode) {
+    this.speciesCode = speciesCode;
+  }
+
+  @Override
+  public List<String> validateFields(String fieldPrefix) throws HandledException {
+    String fieldName = fieldPrefix + "tree_species.";
+    List<String> fields = new ArrayList<>();
+
+    if (genus == null || isEmpty(genus)) {
+      fields.add(fieldName + "genus");
+    }
+    if (species == null) { // species can be empty
+      fields.add(fieldName + "species");
+    }
+    if (commonName == null || isEmpty(commonName)) {
+      fields.add(fieldName + "commonName");
+    }
+    if (speciesCode == null || isEmpty(speciesCode)) {
+      fields.add(fieldName + "speciesCode");
+    }
+
+    return fields;
+  }
+}

--- a/api/src/main/java/com/codeforcommunity/dto/site/StewardshipActivity.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/StewardshipActivity.java
@@ -1,7 +1,7 @@
 package com.codeforcommunity.dto.site;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import java.util.Date;
+import java.sql.Date;
 
 public class StewardshipActivity {
   private final int id;

--- a/api/src/main/java/com/codeforcommunity/dto/site/StewardshipActivity.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/StewardshipActivity.java
@@ -1,11 +1,15 @@
 package com.codeforcommunity.dto.site;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.util.Date;
 
 public class StewardshipActivity {
   private final int id;
   private final int userId;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy", timezone="America/New_York")
   private final Date date;
+
   private final Boolean watered;
   private final Boolean mulched;
   private final Boolean cleaned;

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ImportRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ImportRouter.java
@@ -8,6 +8,8 @@ import com.codeforcommunity.dto.imports.ImportBlocksRequest;
 import com.codeforcommunity.dto.imports.ImportNeighborhoodsRequest;
 import com.codeforcommunity.dto.imports.ImportReservationsRequest;
 import com.codeforcommunity.dto.imports.ImportSitesRequest;
+import com.codeforcommunity.dto.imports.ImportTreeBenefitsRequest;
+import com.codeforcommunity.dto.imports.ImportTreeSpeciesRequest;
 import com.codeforcommunity.rest.IRouter;
 import com.codeforcommunity.rest.RestFunctions;
 import io.vertx.core.Vertx;
@@ -31,6 +33,8 @@ public class ImportRouter implements IRouter {
     registerImportNeighborhoods(router);
     registerImportReservations(router);
     registerImportSites(router);
+    registerImportTreeSpecies(router);
+    registerImportTreeBenefits(router);
 
     return router;
   }
@@ -53,6 +57,16 @@ public class ImportRouter implements IRouter {
   private void registerImportSites(Router router) {
     Route importSitesRoute = router.post("/sites");
     importSitesRoute.handler(this::handleImportSitesRoute);
+  }
+
+  private void registerImportTreeSpecies(Router router) {
+    Route importTreeSpeciesRoute = router.post("/tree_species");
+    importTreeSpeciesRoute.handler(this::handleImportTreeSpeciesRoute);
+  }
+
+  private void registerImportTreeBenefits(Router router) {
+    Route importTreeBenefitsRoute = router.post("/tree_benefits");
+    importTreeBenefitsRoute.handler(this::handleImportTreeBenefitsRoute);
   }
 
   private void handleImportBlocksRoute(RoutingContext ctx) {
@@ -89,7 +103,28 @@ public class ImportRouter implements IRouter {
     JWTData userData = ctx.get("jwt_data");
     ImportSitesRequest importSitesRequest =
         RestFunctions.getJsonBodyAsClass(ctx, ImportSitesRequest.class);
+
     processor.importSites(userData, importSitesRequest);
+
+    end(ctx.response(), 200);
+  }
+
+  private void handleImportTreeSpeciesRoute(RoutingContext ctx) {
+    JWTData userData = ctx.get("jwt_data");
+    ImportTreeSpeciesRequest importTreeSpeciesRequest =
+        RestFunctions.getJsonBodyAsClass(ctx, ImportTreeSpeciesRequest.class);
+
+    processor.importTreeSpecies(userData, importTreeSpeciesRequest);
+
+    end(ctx.response(), 200);
+  }
+
+  private void handleImportTreeBenefitsRoute(RoutingContext ctx) {
+    JWTData userData = ctx.get("jwt_data");
+    ImportTreeBenefitsRequest importTreeBenefitsRequest =
+        RestFunctions.getJsonBodyAsClass(ctx, ImportTreeBenefitsRequest.class);
+
+    processor.importTreeBenefits(userData, importTreeBenefitsRequest);
 
     end(ctx.response(), 200);
   }

--- a/persist/src/main/resources/db/migration/V4__AddTreeBenefits.sql
+++ b/persist/src/main/resources/db/migration/V4__AddTreeBenefits.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS tree_species
+(
+    genus        VARCHAR(20) NOT NULL,
+    species      VARCHAR(20) NOT NULL,
+    common_name  VARCHAR(40) NOT NULL,
+    species_code VARCHAR(10) NOT NULL,
+
+    PRIMARY KEY (genus, species)
+);
+
+CREATE TABLE IF NOT EXISTS tree_benefits
+(
+    species_code       VARCHAR(10)      NOT NULL,
+    diameter           DOUBLE PRECISION NOT NULL,
+    aq_nox_avoided     DOUBLE PRECISION NOT NULL,
+    aq_nox_dep         DOUBLE PRECISION NOT NULL,
+    aq_ozone_dep       DOUBLE PRECISION NOT NULL,
+    aq_pm10_avoided    DOUBLE PRECISION NOT NULL,
+    aq_pm10_dep        DOUBLE PRECISION NOT NULL,
+    aq_sox_avoided     DOUBLE PRECISION NOT NULL,
+    aq_sox_dep         DOUBLE PRECISION NOT NULL,
+    aq_voc_avoided     DOUBLE PRECISION NOT NULL,
+    co2_avoided        DOUBLE PRECISION NOT NULL,
+    co2_sequestered    DOUBLE PRECISION NOT NULL,
+    co2_storage        DOUBLE PRECISION NOT NULL,
+    electricity        DOUBLE PRECISION NOT NULL,
+    hydro_interception DOUBLE PRECISION NOT NULL,
+    natural_gas        DOUBLE PRECISION NOT NULL,
+
+    PRIMARY KEY (species_code, diameter)
+);

--- a/service/src/main/java/com/codeforcommunity/processor/ImportProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ImportProcessorImpl.java
@@ -13,7 +13,11 @@ import com.codeforcommunity.dto.imports.ImportBlocksRequest;
 import com.codeforcommunity.dto.imports.ImportNeighborhoodsRequest;
 import com.codeforcommunity.dto.imports.ImportReservationsRequest;
 import com.codeforcommunity.dto.imports.ImportSitesRequest;
+import com.codeforcommunity.dto.imports.ImportTreeBenefitsRequest;
+import com.codeforcommunity.dto.imports.ImportTreeSpeciesRequest;
 import com.codeforcommunity.dto.imports.NeighborhoodImport;
+import com.codeforcommunity.dto.imports.TreeBenefitImport;
+import com.codeforcommunity.dto.imports.TreeSpeciesImport;
 import com.codeforcommunity.enums.PrivilegeLevel;
 import com.codeforcommunity.exceptions.AuthException;
 import com.codeforcommunity.exceptions.ResourceDoesNotExistException;
@@ -32,6 +36,8 @@ import org.jooq.generated.tables.records.NeighborhoodsRecord;
 import org.jooq.generated.tables.records.ReservationsRecord;
 import org.jooq.generated.tables.records.SiteEntriesRecord;
 import org.jooq.generated.tables.records.SitesRecord;
+import org.jooq.generated.tables.records.TreeBenefitsRecord;
+import org.jooq.generated.tables.records.TreeSpeciesRecord;
 
 public class ImportProcessorImpl implements IImportProcessor {
   private final DSLContext db;
@@ -260,6 +266,54 @@ public class ImportProcessorImpl implements IImportProcessor {
       if (username != null && !username.isEmpty()) {
         importSiteEntryUsername(siteEntryId, pair.getValue());
       }
+    }
+  }
+
+  @Override
+  public void importTreeSpecies(
+      JWTData userData, ImportTreeSpeciesRequest importTreeSpeciesRequest) {
+    if (userData.getPrivilegeLevel() != PrivilegeLevel.SUPER_ADMIN) {
+      throw new AuthException("User does not have the required privilege level.");
+    }
+
+    for (TreeSpeciesImport treeSpeciesImport : importTreeSpeciesRequest.getTreeSpecies()) {
+      TreeSpeciesRecord treeSpecies = db.newRecord(Tables.TREE_SPECIES);
+      treeSpecies.setGenus(treeSpeciesImport.getGenus());
+      treeSpecies.setSpecies(treeSpeciesImport.getSpecies());
+      treeSpecies.setCommonName(treeSpeciesImport.getCommonName());
+      treeSpecies.setSpeciesCode(treeSpeciesImport.getSpeciesCode());
+
+      treeSpecies.store();
+    }
+  }
+
+  @Override
+  public void importTreeBenefits(
+      JWTData userData, ImportTreeBenefitsRequest importTreeBenefitsRequest) {
+    if (userData.getPrivilegeLevel() != PrivilegeLevel.SUPER_ADMIN) {
+      throw new AuthException("User does not have the required privilege level.");
+    }
+
+    for (TreeBenefitImport treeBenefitImport : importTreeBenefitsRequest.getTreeBenefits()) {
+      TreeBenefitsRecord treeBenefits = db.newRecord(Tables.TREE_BENEFITS);
+      treeBenefits.setSpeciesCode(treeBenefitImport.getSpeciesCode());
+      treeBenefits.setDiameter(treeBenefitImport.getDiameter());
+      treeBenefits.setAqNoxAvoided(treeBenefitImport.getAqNoxAvoided());
+      treeBenefits.setAqNoxDep(treeBenefitImport.getAqNoxDep());
+      treeBenefits.setAqOzoneDep(treeBenefitImport.getAqOzoneDep());
+      treeBenefits.setAqPm10Avoided(treeBenefitImport.getAqPm10Avoided());
+      treeBenefits.setAqPm10Dep(treeBenefitImport.getAqPm10Dep());
+      treeBenefits.setAqSoxAvoided(treeBenefitImport.getAqSoxAvoided());
+      treeBenefits.setAqSoxDep(treeBenefitImport.getAqPm10Dep());
+      treeBenefits.setAqVocAvoided(treeBenefitImport.getAqVocAvoided());
+      treeBenefits.setCo2Avoided(treeBenefitImport.getCo2Avoided());
+      treeBenefits.setCo2Sequestered(treeBenefitImport.getCo2Sequestered());
+      treeBenefits.setCo2Storage(treeBenefitImport.getCo2Storage());
+      treeBenefits.setElectricity(treeBenefitImport.getElectricity());
+      treeBenefits.setHydroInterception(treeBenefitImport.getHydroInterception());
+      treeBenefits.setNaturalGas(treeBenefitImport.getNaturalGas());
+
+      treeBenefits.store();
     }
   }
 }


### PR DESCRIPTION
ClickUp ticket: https://app.clickup.com/t/1dk46gh

## This PR

Add two tables, `TREE_SPECIES` and `TREE_BENEFITS`

- `TREE_SPECIES` stores data on a tree species's scientific name, common name, and [i-Tree](https://www.itreetools.org/) code (which is used to look up a tree's environmental benefits in the `TREE_BENEFITS` table explained below
- `TREE_BENEFITS` stores data on the actual environmental benefits (like the amounts of energy conserved and stormwater filtered) for a tree of a given tree species with a given diameter

Add two import routes, `importTreeSpecies` and `importTreeBenefits`, that can be used to populate the `TREE_SPECIES` and `TREE_BENEFITS` tables, respectively, with data from i-Tree
