### PR TITLE
Ot.delete template

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IProtectedEmailerProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedEmailerProcessor.java
@@ -6,4 +6,6 @@ import com.codeforcommunity.dto.emailer.AddTemplateRequest;
 public interface IProtectedEmailerProcessor {
   /** Adds an HTML email template to cloud storage. */
   void addTemplate(JWTData userData, AddTemplateRequest addTemplateRequest);
+  /** Deletes an HTML email template with the given name in cloud storage. */
+  void deleteTemplate(JWTData userData, String templateName);
 }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
@@ -25,6 +25,7 @@ public class ProtectedEmailerRouter implements IRouter {
     Router router = Router.router(vertx);
 
     registerAddTemplate(router);
+    registerDeleteTemplate(router);
 
     return router;
   }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
@@ -60,6 +60,7 @@ public class ProtectedEmailerRouter implements IRouter {
     LoadTemplateResponse loadTemplateResponse = processor.loadTemplate(userData, templateName);
 
     end(ctx.response(), 200, JsonObject.mapFrom(loadTemplateResponse).toString());
+  }
 
   private void registerDeleteTemplate(Router router) {
     Route deleteTemplate = router.post("/delete_template/:template_name");

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
@@ -63,7 +63,7 @@ public class ProtectedEmailerRouter implements IRouter {
   }
 
   private void registerDeleteTemplate(Router router) {
-    Route deleteTemplate = router.post("/delete_template/:template_name");
+    Route deleteTemplate = router.delete("/delete_template/:template_name");
     deleteTemplate.handler(this::handleDeleteTemplate);
   }
 

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
@@ -43,4 +43,18 @@ public class ProtectedEmailerRouter implements IRouter {
 
     end(ctx.response(), 200);
   }
+
+  private void registerDeleteTemplate(Router router) {
+    Route deleteTemplate = router.post("/delete_template/:template_name");
+    deleteTemplate.handler(this::handleDeleteTemplate);
+  }
+
+  private void handleDeleteTemplate(RoutingContext ctx) {
+    JWTData userData = ctx.get("jwt_data");
+    String templateName = RestFunctions.getRequestParameterAsString(ctx.request(), "template_name");
+
+    processor.deleteTemplate(userData, templateName);
+
+    end(ctx.response(), 200);
+  }
 }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
@@ -57,6 +57,7 @@ public class ProtectedEmailerProcessorImpl extends AbstractProcessor
     );
 
     return loadTemplateResponse;
+  }
 
   @Override
   public void deleteTemplate(JWTData userData, String templateName) {

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
@@ -4,15 +4,10 @@ import com.codeforcommunity.api.IProtectedEmailerProcessor;
 import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dto.emailer.AddTemplateRequest;
 import com.codeforcommunity.dto.emailer.LoadTemplateResponse;
-import com.codeforcommunity.dto.leaderboard.LeaderboardEntry;
-import com.codeforcommunity.enums.PrivilegeLevel;
-import com.codeforcommunity.enums.ReservationAction;
 import com.codeforcommunity.exceptions.UserDoesNotExistException;
 import com.codeforcommunity.requester.S3Requester;
 
 import org.jooq.DSLContext;
-
-import java.util.List;
 
 import static org.jooq.impl.DSL.count;
 import static org.jooq.generated.tables.Users.USERS;
@@ -62,6 +57,6 @@ public class ProtectedEmailerProcessorImpl extends AbstractProcessor
   @Override
   public void deleteTemplate(JWTData userData, String templateName) {
     assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
-    S3Requester.deleteHTML(templateName, "email_templates");
+    S3Requester.deleteHTML(templateName, TEMPLATE_DIR);
   }
 }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
@@ -17,4 +17,10 @@ public class ProtectedEmailerProcessorImpl extends AbstractProcessor
         userData.getUserId(),
         addTemplateRequest.getTemplate());
   }
+
+  @Override
+  public void deleteTemplate(JWTData userData, String templateName) {
+    assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
+    S3Requester.deleteHTML(templateName, "email_templates");
+  }
 }

--- a/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
+++ b/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
@@ -337,14 +337,9 @@ public class S3Requester {
    * @throws SdkClientException if the deletion from S3 failed.
    */
   public static void deleteHTML(String name, String directoryName) {
-    String HTMLPath = directoryName + "/" + name;
+    String HTMLPath = directoryName + "/" + name + "_template.html";
 
-    // if the object does not exist, it throws a 403 for metadata?
-    try {
-      Boolean htmlExists = externs.getS3Client().doesObjectExist(externs.getBucketPublic(), HTMLPath);
-    } catch(AmazonServiceException e) {
-      throw new InvalidURLException();
-    }
+    Boolean htmlExists = externs.getS3Client().doesObjectExist(externs.getBucketPublic(), HTMLPath);
 
     // Create the request to delete the HTML
     DeleteObjectRequest awsRequest = new DeleteObjectRequest(externs.getBucketPublic(), HTMLPath);

--- a/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
+++ b/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
@@ -1,5 +1,6 @@
 package com.codeforcommunity.requester;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
@@ -286,9 +287,11 @@ public class S3Requester {
    */
   public static String deleteHTML(String name, String directoryName) {
     String HTMLPath = directoryName + "/" + name;
-    Boolean htmlExists = externs.getS3Client().doesObjectExist(externs.getBucketPublic(), HTMLPath);
 
-    if (!htmlExists) {
+    // if the object does not exist, it throws a 403 for metadata?
+    try {
+      Boolean htmlExists = externs.getS3Client().doesObjectExist(externs.getBucketPublic(), HTMLPath);
+    } catch(AmazonServiceException e) {
       throw new InvalidURLException();
     }
 

--- a/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
+++ b/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
@@ -317,7 +317,7 @@ public class S3Requester {
       while ((c = HTMLFile.getObjectContent().read()) != -1) {
         content.append((char) c);
       }
-    } catch(IOException e) {
+    } catch (IOException e) {
       throw new BadRequestHTMLException("HTML file could not be decoded to string");
     }
 
@@ -326,17 +326,17 @@ public class S3Requester {
     String htmlAuthor = HTMLFile.getObjectMetadata().getUserMetaDataOf("userID");
 
     return new LoadTemplateResponse(HTMLContent, HTMLFile.getKey(), htmlAuthor);
+  }
 
   /**
    * Delete the existing HTML file with the given name from the user uploads S3 bucket.
    *
    * @param name the name of the HTML file in S3 to be deleted.
    * @param directoryName the directory of the file in S3 (without leading or trailing '/').
-   * @return previously existing HTML file URL if the deletion was successful.
    * @throws InvalidURLException if the file does not exist.
    * @throws SdkClientException if the deletion from S3 failed.
    */
-  public static String deleteHTML(String name, String directoryName) {
+  public static void deleteHTML(String name, String directoryName) {
     String HTMLPath = directoryName + "/" + name;
 
     // if the object does not exist, it throws a 403 for metadata?
@@ -350,7 +350,5 @@ public class S3Requester {
     DeleteObjectRequest awsRequest = new DeleteObjectRequest(externs.getBucketPublic(), HTMLPath);
 
     externs.getS3Client().deleteObject(awsRequest);
-
-    return String.format("%s/%s/%s", externs.getBucketPublicUrl(), directoryName, name);
   }
 }

--- a/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
+++ b/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
@@ -337,12 +337,14 @@ public class S3Requester {
    * @throws SdkClientException if the deletion from S3 failed.
    */
   public static void deleteHTML(String name, String directoryName) {
-    String HTMLPath = directoryName + "/" + name + "_template.html";
+    String htmlPath = directoryName + "/" + name + "_template.html";
 
-    Boolean htmlExists = externs.getS3Client().doesObjectExist(externs.getBucketPublic(), HTMLPath);
+    if (!pathExists(htmlPath)) {
+      throw new InvalidURLException();
+    }
 
     // Create the request to delete the HTML
-    DeleteObjectRequest awsRequest = new DeleteObjectRequest(externs.getBucketPublic(), HTMLPath);
+    DeleteObjectRequest awsRequest = new DeleteObjectRequest(externs.getBucketPublic(), htmlPath);
 
     externs.getS3Client().deleteObject(awsRequest);
   }


### PR DESCRIPTION
## Checklist

- [ ] 1. Change ClickUp ticket status to "In Review"
- [ ] 2. After making the PR, add PR link to ClickUp ticket

## Why

[ClickUp Ticket](https://app.clickup.com/t/xxxxxxx)

Allows admins to delete existing email templates in the email-templates folder of the sftt-user-uploads bucket

## This PR

First checks if the file exists with `doesObjectExist`; however instead of returning `false` if the file does not exist, it throws an exception (seems to come from trying to access metadata) for a 403 forbidden error. Tried to enable attribute permissions on the bucket but doesn't work. Might have to instantiate S3 client with credentials for it to work? Works fine (returns `true`) with the file does actually exist.

There might be a better workaround, but I catch the S3 exception and throw an `InvaliURLException` instead.

## Verification Steps

Calling a POST request `http://localhost:8081/api/v1/protected/emailer/delete_template/[some existing name].html`
removes that file from the S3 folder