### PR TITLE
load email tempalte first iter

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IProtectedEmailerProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedEmailerProcessor.java
@@ -2,8 +2,12 @@ package com.codeforcommunity.api;
 
 import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dto.emailer.AddTemplateRequest;
+import com.codeforcommunity.dto.emailer.LoadTemplateResponse;
 
 public interface IProtectedEmailerProcessor {
   /** Adds an HTML email template to cloud storage. */
   void addTemplate(JWTData userData, AddTemplateRequest addTemplateRequest);
+
+  /** Loads an HTML email template from cloud storage. */
+  LoadTemplateResponse loadTemplate(JWTData userData, String templateName);
 }

--- a/api/src/main/java/com/codeforcommunity/dto/emailer/LoadTemplateResponse.java
+++ b/api/src/main/java/com/codeforcommunity/dto/emailer/LoadTemplateResponse.java
@@ -1,0 +1,25 @@
+package com.codeforcommunity.dto.emailer;
+
+public class LoadTemplateResponse {
+  String name;
+  String template;
+  String author;
+
+  public LoadTemplateResponse(String template, String name, String author) {
+    this.template = template;
+    this.name = name;
+    this.author = author;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getTemplate() {
+    return template;
+  }
+
+  public String getAuthor() {
+    return author;
+  }
+}

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
@@ -5,9 +5,11 @@ import static com.codeforcommunity.rest.ApiRouter.end;
 import com.codeforcommunity.api.IProtectedEmailerProcessor;
 import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dto.emailer.AddTemplateRequest;
+import com.codeforcommunity.dto.emailer.LoadTemplateResponse;
 import com.codeforcommunity.rest.IRouter;
 import com.codeforcommunity.rest.RestFunctions;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -25,6 +27,7 @@ public class ProtectedEmailerRouter implements IRouter {
     Router router = Router.router(vertx);
 
     registerAddTemplate(router);
+    registerLoadTemplate(router);
 
     return router;
   }
@@ -42,5 +45,19 @@ public class ProtectedEmailerRouter implements IRouter {
     processor.addTemplate(userData, addTemplateRequest);
 
     end(ctx.response(), 200);
+  }
+
+  private void registerLoadTemplate(Router router) {
+    Route loadTemplate = router.get("/load_template/:template_name");
+    loadTemplate.handler(this::handleLoadTemplate);
+  }
+
+  private void handleLoadTemplate(RoutingContext ctx) {
+    JWTData userData = ctx.get("jwt_data");
+    String templateName = RestFunctions.getRequestParameterAsString(ctx.request(), "template_name");
+
+    LoadTemplateResponse loadTemplateResponse = processor.loadTemplate(userData, templateName);
+
+    end(ctx.response(), 200, JsonObject.mapFrom(loadTemplateResponse).toString());
   }
 }

--- a/service/src/main/java/com/codeforcommunity/ServiceMain.java
+++ b/service/src/main/java/com/codeforcommunity/ServiceMain.java
@@ -115,7 +115,7 @@ public class ServiceMain {
     IReportProcessor reportProc = new ReportProcessorImpl(this.db);
     IProtectedNeighborhoodsProcessor protectedNeighborhoodsProc =
         new ProtectedNeighborhoodsProcessorImpl(this.db, emailer);
-    IProtectedEmailerProcessor emailerProc = new ProtectedEmailerProcessorImpl();
+    IProtectedEmailerProcessor emailerProc = new ProtectedEmailerProcessorImpl(this.db);
 
     // Create the API router and start the HTTP server
     ApiRouter router =

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
@@ -3,6 +3,7 @@ package com.codeforcommunity.processor;
 import com.codeforcommunity.api.IProtectedEmailerProcessor;
 import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dto.emailer.AddTemplateRequest;
+import com.codeforcommunity.dto.emailer.LoadTemplateResponse;
 import com.codeforcommunity.requester.S3Requester;
 
 public class ProtectedEmailerProcessorImpl extends AbstractProcessor
@@ -16,5 +17,12 @@ public class ProtectedEmailerProcessorImpl extends AbstractProcessor
         "email_templates",
         userData.getUserId(),
         addTemplateRequest.getTemplate());
+  }
+
+  @Override
+  public LoadTemplateResponse loadTemplate(JWTData userData, String templateName) {
+    assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
+    LoadTemplateResponse loadTemplateResponse = S3Requester.loadHTML(templateName, "email_templates");
+    return loadTemplateResponse;
   }
 }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
@@ -4,12 +4,28 @@ import com.codeforcommunity.api.IProtectedEmailerProcessor;
 import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dto.emailer.AddTemplateRequest;
 import com.codeforcommunity.dto.emailer.LoadTemplateResponse;
+import com.codeforcommunity.dto.leaderboard.LeaderboardEntry;
+import com.codeforcommunity.enums.PrivilegeLevel;
+import com.codeforcommunity.enums.ReservationAction;
+import com.codeforcommunity.exceptions.UserDoesNotExistException;
 import com.codeforcommunity.requester.S3Requester;
+
+import org.jooq.DSLContext;
+
+import java.util.List;
+
+import static org.jooq.impl.DSL.count;
+import static org.jooq.generated.tables.Users.USERS;
+import org.jooq.generated.tables.records.UsersRecord;
 
 public class ProtectedEmailerProcessorImpl extends AbstractProcessor
     implements IProtectedEmailerProcessor {
 
   static public String TEMPLATE_DIR = "email_templates";
+
+  private final DSLContext db;
+
+  public ProtectedEmailerProcessorImpl(DSLContext db) { this.db = db; }
 
   @Override
   public void addTemplate(JWTData userData, AddTemplateRequest addTemplateRequest) {
@@ -24,7 +40,22 @@ public class ProtectedEmailerProcessorImpl extends AbstractProcessor
   @Override
   public LoadTemplateResponse loadTemplate(JWTData userData, String templateName) {
     assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
-    LoadTemplateResponse loadTemplateResponse = S3Requester.loadHTML(templateName, TEMPLATE_DIR);
+    LoadTemplateResponse s3Response = S3Requester.loadHTML(templateName, TEMPLATE_DIR);
+    int userId = Integer.parseInt(s3Response.getAuthor());
+    // has ID of author, replace with fullname of author
+    UsersRecord user = db.selectFrom(USERS)
+            .where(USERS.ID.eq(userId)).fetchOne();
+    if (user == null) {
+      throw new UserDoesNotExistException(userId);
+    }
+
+    String fullname = user.getFirstName() + " " + user.getLastName();
+    LoadTemplateResponse loadTemplateResponse = new LoadTemplateResponse(
+            s3Response.getTemplate(),
+            s3Response.getName(),
+            fullname
+    );
+
     return loadTemplateResponse;
   }
 }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
@@ -9,12 +9,14 @@ import com.codeforcommunity.requester.S3Requester;
 public class ProtectedEmailerProcessorImpl extends AbstractProcessor
     implements IProtectedEmailerProcessor {
 
+  static public String TEMPLATE_DIR = "email_templates";
+
   @Override
   public void addTemplate(JWTData userData, AddTemplateRequest addTemplateRequest) {
     assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
     S3Requester.uploadHTML(
         addTemplateRequest.getName(),
-        "email_templates",
+        TEMPLATE_DIR,
         userData.getUserId(),
         addTemplateRequest.getTemplate());
   }
@@ -22,7 +24,7 @@ public class ProtectedEmailerProcessorImpl extends AbstractProcessor
   @Override
   public LoadTemplateResponse loadTemplate(JWTData userData, String templateName) {
     assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
-    LoadTemplateResponse loadTemplateResponse = S3Requester.loadHTML(templateName, "email_templates");
+    LoadTemplateResponse loadTemplateResponse = S3Requester.loadHTML(templateName, TEMPLATE_DIR);
     return loadTemplateResponse;
   }
 }

--- a/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
+++ b/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
@@ -285,8 +285,7 @@ public class S3Requester {
 
   // helper to check whether the given path exists
   public static boolean pathExists(String path) {
-    Boolean exists = externs.getS3Client().doesObjectExist(externs.getBucketPublic(), path);
-    return exists;
+    return externs.getS3Client().doesObjectExist(externs.getBucketPublic(), path);
   }
 
   /**
@@ -300,14 +299,14 @@ public class S3Requester {
    * @throws SdkClientException if the loading from S3 failed.
    */
   public static LoadTemplateResponse loadHTML(String name, String directoryName) {
-    String HTMLPath = directoryName + "/" + name + "_template.html";
+    String htmlPath = directoryName + "/" + name + "_template.html";
 
-    if (!pathExists(HTMLPath)) {
+    if (!pathExists(htmlPath)) {
       throw new InvalidURLException();
     }
 
     // Create the request to delete the HTML
-    GetObjectRequest awsRequest = new GetObjectRequest(externs.getBucketPublic(), HTMLPath);
+    GetObjectRequest awsRequest = new GetObjectRequest(externs.getBucketPublic(), htmlPath);
 
     S3Object HTMLFile = externs.getS3Client().getObject(awsRequest);
     StringBuilder content = new StringBuilder();
@@ -322,8 +321,8 @@ public class S3Requester {
 
     String HTMLContent = content.toString();
 
-    String HTMLAuthor = HTMLFile.getObjectMetadata().getUserMetaDataOf("userID");
+    String htmlAuthor = HTMLFile.getObjectMetadata().getUserMetaDataOf("userID");
 
-    return new LoadTemplateResponse(HTMLContent, HTMLFile.getKey(), HTMLAuthor);
+    return new LoadTemplateResponse(HTMLContent, HTMLFile.getKey(), htmlAuthor);
   }
 }


### PR DESCRIPTION
## Checklist

- [ ] 1. Change ClickUp ticket status to "In Review"
- [ ] 2. After making the PR, add PR link to ClickUp ticket

## Why

[ClickUp Ticket](https://app.clickup.com/t/xxxxxxx)

Allows admins to load existing email templates (retrieve the name, html content, author) in the email-templates folder of the sftt-user-uploads bucket

## This PR

First checks if the file exists with doesObjectExist; however instead of returning false if the file does not exist, it throws an exception (seems to come from trying to access metadata) for a 403 forbidden error. Tried to enable attribute permissions on the bucket but doesn't work. Might have to instantiate S3 client with credentials for it to work? Works fine (returns true) with the file does actually exist.

There might be a better workaround, but I catch the S3 exception and throw an InvaliURLException instead.

## Verification Steps

Making a GET request `http://localhost:8081/api/v1/protected/emailer/load_template/[some existing name].html`
responds with a json
'''
{
    "name": "[directory]/[name].html",
    "template": "[html content]",
    "author": "[admin id]"
}
'''
