### PR TITLE
Ot.edit template

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IProtectedEmailerProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedEmailerProcessor.java
@@ -6,4 +6,6 @@ import com.codeforcommunity.dto.emailer.AddTemplateRequest;
 public interface IProtectedEmailerProcessor {
   /** Adds an HTML email template to cloud storage. */
   void addTemplate(JWTData userData, AddTemplateRequest addTemplateRequest);
+  /** Edits an HTML email template on cloud storage. */
+  void editTemplate(JWTData userData, String templateName, AddTemplateRequest addTemplateRequest);
 }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
@@ -25,6 +25,7 @@ public class ProtectedEmailerRouter implements IRouter {
     Router router = Router.router(vertx);
 
     registerAddTemplate(router);
+    registerEditTemplate(router);
 
     return router;
   }
@@ -40,6 +41,22 @@ public class ProtectedEmailerRouter implements IRouter {
         RestFunctions.getJsonBodyAsClass(ctx, AddTemplateRequest.class);
 
     processor.addTemplate(userData, addTemplateRequest);
+
+    end(ctx.response(), 200);
+  }
+
+  private void registerEditTemplate(Router router) {
+    Route editTemplate = router.post("/edit_template/:template_name");
+    editTemplate.handler(this::handleEditTemplate);
+  }
+
+  private void handleEditTemplate(RoutingContext ctx) {
+    JWTData userData = ctx.get("jwt_data");
+    String templateName = RestFunctions.getRequestParameterAsString(ctx.request(), "template_name");
+    AddTemplateRequest editTemplateRequest =
+            RestFunctions.getJsonBodyAsClass(ctx, AddTemplateRequest.class);
+
+    processor.editTemplate(userData, templateName, editTemplateRequest);
 
     end(ctx.response(), 200);
   }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
@@ -17,4 +17,14 @@ public class ProtectedEmailerProcessorImpl extends AbstractProcessor
         userData.getUserId(),
         addTemplateRequest.getTemplate());
   }
+
+  @Override
+  public void editTemplate(JWTData userData, String templateName, AddTemplateRequest addTemplateRequest) {
+    assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
+    S3Requester.overwriteHTML(
+            templateName,
+            "email_templates",
+            userData.getUserId(),
+            addTemplateRequest.getTemplate());
+  }
 }

--- a/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
+++ b/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
@@ -299,8 +299,9 @@ public class S3Requester {
     } catch(AmazonServiceException e) {
       throw new InvalidURLException();
     }
+    String name_no_suffix = name.substring(0, (name.length()-"_template.html".length()));
 
-    String overwriteResponse = uploadHTML(name, directoryName, adminID, htmlContent);
+    String overwriteResponse = uploadHTML(name_no_suffix, directoryName, adminID, htmlContent);
     return overwriteResponse;
   }
 }


### PR DESCRIPTION
## Checklist

- [ ] 1. Change ClickUp ticket status to "In Review"
- [ ] 2. After making the PR, add PR link to ClickUp ticket

## Why

[ClickUp Ticket](https://app.clickup.com/t/xxxxxxx)

Allows admins to edit (overwrite) an existing email template in the email-templates folder of the sftt-user-uploads bucket

## This PR

First checks if the file exists with doesObjectExist; however instead of returning false if the file does not exist, it throws an exception (seems to come from trying to access metadata) for a 403 forbidden error. Tried to enable attribute permissions on the bucket but doesn't work. Might have to instantiate S3 client with credentials for it to work? Works fine (returns true) with the file does actually exist.

There might be a better workaround, but I catch the S3 exception and throw an InvaliURLException instead.

Also-- may not be optimal, but uses the existing `AddTemplateRequest` dto but ignores the `"name"` (only cares about `"template"`) attribute/key since that is taken from the query string `:template_name` instead.

## Verification Steps

Making a POST request http://localhost:8081/api/v1/protected/emailer/edit_template/[some existing name].html
responds with 200 and the object in S3's content has changed