### PR TITLE
Reset tree name when tree is unadopted or force unadopted

### DIFF
--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -236,9 +236,23 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
       throw new WrongAdoptionStatusException(false);
     }
 
-    db.deleteFrom(ADOPTED_SITES)
-        .where(ADOPTED_SITES.USER_ID.eq(userData.getUserId()))
-        .and(ADOPTED_SITES.SITE_ID.eq(siteId))
+    db.transaction(
+        configuration -> {
+          db.deleteFrom(ADOPTED_SITES)
+              .where(ADOPTED_SITES.USER_ID.eq(userData.getUserId()))
+              .and(ADOPTED_SITES.SITE_ID.eq(siteId))
+              .execute();
+
+          this.resetTreeName(siteId);
+        });
+  }
+
+  private void resetTreeName(int siteId) {
+    int latestSiteEntryId = this.latestSiteEntry(siteId).getId();
+
+    db.update(SITE_ENTRIES)
+        .setNull(SITE_ENTRIES.TREE_NAME)
+        .where(SITE_ENTRIES.ID.eq(latestSiteEntryId))
         .execute();
   }
 
@@ -265,7 +279,13 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
       throw new AuthException("User does not have the required privilege level.");
     }
 
-    db.deleteFrom(ADOPTED_SITES).where(ADOPTED_SITES.SITE_ID.eq(siteId)).execute();
+    db.transaction(
+        configuration -> {
+          db.deleteFrom(ADOPTED_SITES).where(ADOPTED_SITES.SITE_ID.eq(siteId)).execute();
+
+          this.resetTreeName(siteId);
+        }
+    );
   }
 
   @Override
@@ -531,12 +551,7 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
     checkSiteExists(siteId);
     checkAdminOrSiteAdopter(userData, siteId);
 
-    SiteEntriesRecord siteEntry =
-        db.selectFrom(SITE_ENTRIES)
-            .where(SITE_ENTRIES.SITE_ID.eq(siteId))
-            .orderBy(SITE_ENTRIES.UPDATED_AT.desc())
-            .fetchOne();
-
+    SiteEntriesRecord siteEntry = this.latestSiteEntry(siteId);
     if (siteEntry == null) {
       throw new LinkedResourceDoesNotExistException(
           "Site Entry", userData.getUserId(), "User", siteId, "Site");
@@ -549,6 +564,14 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
     }
 
     siteEntry.store();
+  }
+
+  private SiteEntriesRecord latestSiteEntry(int siteId) {
+    return db.selectFrom(SITE_ENTRIES)
+        .where(SITE_ENTRIES.SITE_ID.eq(siteId))
+        .orderBy(SITE_ENTRIES.UPDATED_AT.desc())
+        .fetchInto(SiteEntriesRecord.class)
+        .get(0);
   }
 
   @Override

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -569,7 +569,7 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
   private SiteEntriesRecord latestSiteEntry(int siteId) {
     return db.selectFrom(SITE_ENTRIES)
         .where(SITE_ENTRIES.SITE_ID.eq(siteId))
-        .orderBy(SITE_ENTRIES.UPDATED_AT.desc())
+        .orderBy(SITE_ENTRIES.CREATED_AT.desc())
         .fetchInto(SiteEntriesRecord.class)
         .get(0);
   }


### PR DESCRIPTION
## Checklist

- [ ] 1. Change ClickUp ticket status to "In Review"
- [ ] 2. After making the PR, add PR link to ClickUp ticket

## Why

[GH Projects Ticket](https://github.com/orgs/Code-4-Community/projects/15/views/1?pane=issue&itemId=30450878)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
A user shouldn't be able to adopt a tree, name it something, and unadopt it while keeping its name, especially since there isn't a dedicated tree name review process and users can name any tree they adopt to anything they want atm.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
In both the unadopt and force unadopt routes, in addition to unadopting the specified site, query its latest site entry and reset its name (i.e. change it back to `null`).

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->
Manually verified that unadopting or force unadopting a tree sets the name of its latest site entry to `null`
