### PR TITLE
add tree presence checking

### DIFF
--- a/api/src/main/java/com/codeforcommunity/exceptions/NoTreePresentException.java
+++ b/api/src/main/java/com/codeforcommunity/exceptions/NoTreePresentException.java
@@ -1,0 +1,19 @@
+package com.codeforcommunity.exceptions;
+
+import com.codeforcommunity.rest.FailureHandler;
+
+import io.vertx.ext.web.RoutingContext;
+
+public class NoTreePresentException extends HandledException {
+
+  private final int siteId;
+
+  public NoTreePresentException(int siteId) {
+    this.siteId = siteId;
+  }
+
+  @Override
+  public void callHandler(FailureHandler handler, RoutingContext ctx) {
+    handler.handleNoTreePresentException(ctx, this.siteId);
+  }
+}

--- a/api/src/main/java/com/codeforcommunity/rest/FailureHandler.java
+++ b/api/src/main/java/com/codeforcommunity/rest/FailureHandler.java
@@ -260,6 +260,11 @@ public class FailureHandler {
     end(ctx, message, 400);
   }
 
+  public void handleNoTreePresentException(RoutingContext ctx, int siteId) {
+    String message = String.format("No tree present at site %d", siteId);
+    end(ctx, message, 400);
+  }
+
   private void handleUncaughtError(RoutingContext ctx, Throwable throwable) {
     String message = String.format("Internal server error caused by: %s", throwable.getMessage());
     logger.error(message);

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -36,6 +36,7 @@ import com.codeforcommunity.exceptions.AuthException;
 import com.codeforcommunity.exceptions.HandledException;
 import com.codeforcommunity.exceptions.InvalidCSVException;
 import com.codeforcommunity.exceptions.LinkedResourceDoesNotExistException;
+import com.codeforcommunity.exceptions.NoTreePresentException;
 import com.codeforcommunity.exceptions.ResourceDoesNotExistException;
 import com.codeforcommunity.exceptions.WrongAdoptionStatusException;
 import com.fasterxml.jackson.databind.MappingIterator;
@@ -237,6 +238,10 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
     checkSiteExists(siteId);
     if (isAlreadyAdopted(siteId)) {
       throw new WrongAdoptionStatusException(true);
+    }
+    // prevent users from adopting a site with no tree
+    if (!latestSiteEntry(siteId).getTreePresent()) {
+      throw new NoTreePresentException(siteId);
     }
 
     AdoptedSitesRecord record = db.newRecord(ADOPTED_SITES);

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -774,7 +774,10 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
 
     db.transaction(configuration -> {
       siteEntriesRecord.store();
-      if (!editSiteEntryRequest.isTreePresent() && isAlreadyAdopted(siteId)) {
+      // force unadopt only if we change the latest site entry of an adopted site to have no tree
+      if (!editSiteEntryRequest.isTreePresent()
+          && isAlreadyAdopted(siteId)
+          && entryId == latestSiteEntry(siteId).getId()) {
         forceUnadoptSite(userData, siteId);
       }
     });


### PR DESCRIPTION
## Why

Resolves #187 

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

- Adopting sites now checks if the associated entry has a tree present, throws an exception if not

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

## Verification Steps

- Correctly returns a 400 and doesn't adopt the site when attempting to adopt a site with no tree present 
- Correctly returns a 200 and adopts the site when attempting to adopt a site with a tree present

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->
