### PR TITLE
Tonk.approve site image

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -107,4 +107,7 @@ public interface IProtectedSiteProcessor {
 
   /** Edits the site entry with the given entryId */
   void editSiteEntry(JWTData userData, int entryId, UpdateSiteRequest editSiteEntryRequest);
+
+  /** Allows Admin users to approve uploaded site images of the given ID */
+  void approveSiteImage(JWTData userData, int imageID);
 }

--- a/api/src/main/java/com/codeforcommunity/dto/imports/TreeSpeciesImport.java
+++ b/api/src/main/java/com/codeforcommunity/dto/imports/TreeSpeciesImport.java
@@ -13,7 +13,8 @@ public class TreeSpeciesImport extends ApiDto {
 
   private String defaultImage;
 
-  public TreeSpeciesImport(String genus, String species, String commonName, String speciesCode, String defaultImage) {
+  public TreeSpeciesImport(
+      String genus, String species, String commonName, String speciesCode, String defaultImage) {
     this.genus = genus;
     this.species = species;
     this.commonName = commonName;

--- a/api/src/main/java/com/codeforcommunity/dto/site/SiteEntry.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/SiteEntry.java
@@ -61,6 +61,7 @@ public class SiteEntry {
       pattern = "MM/dd/yyyy",
       timezone = "America/New_York")
   private final Date plantingDate;
+
   private final List<SiteEntryImage> images;
 
   /* Cambridge fields */
@@ -608,5 +609,4 @@ public class SiteEntry {
   public String getLastEditedUser() {
     return lastEditedUser;
   }
-
 }

--- a/api/src/main/java/com/codeforcommunity/dto/site/SiteEntryImage.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/SiteEntryImage.java
@@ -1,7 +1,6 @@
 package com.codeforcommunity.dto.site;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-
 import java.sql.Timestamp;
 
 public class SiteEntryImage {
@@ -17,7 +16,8 @@ public class SiteEntryImage {
     this(null, null, null, imageUrl);
   }
 
-  public SiteEntryImage(Integer imageId, String uploaderUsername, Timestamp uploadedAt, String imageUrl) {
+  public SiteEntryImage(
+      Integer imageId, String uploaderUsername, Timestamp uploadedAt, String imageUrl) {
     this.imageId = imageId;
     this.uploaderUsername = uploaderUsername;
     this.uploadedAt = uploadedAt;

--- a/api/src/main/java/com/codeforcommunity/exceptions/NoTreePresentException.java
+++ b/api/src/main/java/com/codeforcommunity/exceptions/NoTreePresentException.java
@@ -1,7 +1,6 @@
 package com.codeforcommunity.exceptions;
 
 import com.codeforcommunity.rest.FailureHandler;
-
 import io.vertx.ext.web.RoutingContext;
 
 public class NoTreePresentException extends HandledException {

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -63,6 +63,7 @@ public class ProtectedSiteRouter implements IRouter {
     registerDeleteSiteImage(router);
     registerFilterSites(router);
     registerEditSiteEntry(router);
+    registerApproveSiteImage(router);
 
     return router;
   }
@@ -398,6 +399,20 @@ public class ProtectedSiteRouter implements IRouter {
         RestFunctions.getJsonBodyAsClass(ctx, UpdateSiteRequest.class);
 
     processor.editSiteEntry(userData, entryId, editSiteEntryRequest);
+
+    end(ctx.response(), 200);
+  }
+
+  private void registerApproveSiteImage(Router router){
+    Route approveSiteImage = router.put("/approve_image/:image_id");
+    approveSiteImage.handler(this::handleApproveSiteImage);
+  }
+
+  private void handleApproveSiteImage(RoutingContext ctx){
+    JWTData userData = ctx.get("jwt_data");
+    int imageID = RestFunctions.getRequestParameterAsInt(ctx.request(), "image_id");
+
+    processor.approveSiteImage(userData, imageID);
 
     end(ctx.response(), 200);
   }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -403,12 +403,12 @@ public class ProtectedSiteRouter implements IRouter {
     end(ctx.response(), 200);
   }
 
-  private void registerApproveSiteImage(Router router){
+  private void registerApproveSiteImage(Router router) {
     Route approveSiteImage = router.put("/approve_image/:image_id");
     approveSiteImage.handler(this::handleApproveSiteImage);
   }
 
-  private void handleApproveSiteImage(RoutingContext ctx){
+  private void handleApproveSiteImage(RoutingContext ctx) {
     JWTData userData = ctx.get("jwt_data");
     int imageID = RestFunctions.getRequestParameterAsInt(ctx.request(), "image_id");
 

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -879,8 +879,9 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
   public void approveSiteImage(JWTData userData, int imageID) {
     assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
     checkImageExists(imageID);
-    SiteImagesRecord imageRecord = db.selectFrom(SITE_IMAGES).where(SITE_IMAGES.ID.eq(imageID)).fetchOne();
-    imageRecord.setApprovalStatus("Approved");
+    SiteImagesRecord imageRecord =
+        db.selectFrom(SITE_IMAGES).where(SITE_IMAGES.ID.eq(imageID)).fetchOne();
+    imageRecord.setApprovalStatus(ImageApprovalStatus.APPROVED.getApprovalStatus());
     imageRecord.store();
   }
 }

--- a/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
@@ -17,8 +17,8 @@ import com.codeforcommunity.dto.site.SiteEntry;
 import com.codeforcommunity.dto.site.SiteEntryImage;
 import com.codeforcommunity.dto.site.StewardshipActivitiesResponse;
 import com.codeforcommunity.dto.site.StewardshipActivity;
-import com.codeforcommunity.enums.ImageApprovalStatus;
 import com.codeforcommunity.dto.site.TreeBenefitsResponse;
+import com.codeforcommunity.enums.ImageApprovalStatus;
 import com.codeforcommunity.enums.SiteOwner;
 import com.codeforcommunity.exceptions.ResourceDoesNotExistException;
 import com.codeforcommunity.logger.SLogger;
@@ -26,7 +26,6 @@ import com.codeforcommunity.requester.TreeBenefitsCalculator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.jooq.DSLContext;
 import org.jooq.generated.tables.records.AdoptedSitesRecord;
 import org.jooq.generated.tables.records.SiteEntriesRecord;
@@ -184,34 +183,45 @@ public class SiteProcessorImpl implements ISiteProcessor {
   }
 
   private List<SiteEntryImage> getSiteEntryImages(int entryId, String commonName) {
-    List<SiteImagesRecord> imageRecords = db.selectFrom(SITE_IMAGES)
-        .where(SITE_IMAGES.SITE_ENTRY_ID.eq(entryId))
-        .and(SITE_IMAGES.APPROVAL_STATUS.eq(ImageApprovalStatus.APPROVED.getApprovalStatus()))
-        .orderBy(SITE_IMAGES.UPLOADED_AT.desc())
-        .fetch();
+    List<SiteImagesRecord> imageRecords =
+        db.selectFrom(SITE_IMAGES)
+            .where(SITE_IMAGES.SITE_ENTRY_ID.eq(entryId))
+            .and(SITE_IMAGES.APPROVAL_STATUS.eq(ImageApprovalStatus.APPROVED.getApprovalStatus()))
+            .orderBy(SITE_IMAGES.UPLOADED_AT.desc())
+            .fetch();
 
     if (!imageRecords.isEmpty()) {
-      return imageRecords.stream().map(record -> {
-        String username;
-        if (record.getAnonymous()) {
-          username = "Anonymous";
-        } else {
-          username = db.selectFrom(USERS)
-              .where(USERS.ID.eq(record.getUploaderId()))
-              .fetchOne().getUsername();
-        }
+      return imageRecords.stream()
+          .map(
+              record -> {
+                String username;
+                if (record.getAnonymous()) {
+                  username = "Anonymous";
+                } else {
+                  username =
+                      db.selectFrom(USERS)
+                          .where(USERS.ID.eq(record.getUploaderId()))
+                          .fetchOne()
+                          .getUsername();
+                }
 
-        return new SiteEntryImage(record.getId(), username, record.getUploadedAt(), record.getImageUrl());
-      }).collect(Collectors.toList());
+                return new SiteEntryImage(
+                    record.getId(), username, record.getUploadedAt(), record.getImageUrl());
+              })
+          .collect(Collectors.toList());
     }
 
     // if no approved images exist for the entry, check if its tree has a default image.
-    // to counter any minor differences in tree name (e.g. Honey locust vs Honeylocust), 
-    // normalize the tree's common name by setting the name to all lowercase and removing empty spaces
-    String defaultUrl = db.select(TREE_SPECIES.DEFAULT_IMAGE).from(TREE_SPECIES)
-        .where(lower(replace(TREE_SPECIES.COMMON_NAME, " ", ""))
-            .eq(commonName.toLowerCase().replace(" ", "")))
-        .fetchOne(0, String.class);
+    // to counter any minor differences in tree name (e.g. Honey locust vs Honeylocust),
+    // normalize the tree's common name by setting the name to all lowercase and removing empty
+    // spaces
+    String defaultUrl =
+        db.select(TREE_SPECIES.DEFAULT_IMAGE)
+            .from(TREE_SPECIES)
+            .where(
+                lower(replace(TREE_SPECIES.COMMON_NAME, " ", ""))
+                    .eq(commonName.toLowerCase().replace(" ", "")))
+            .fetchOne(0, String.class);
 
     if (defaultUrl != null) {
       List<SiteEntryImage> images = new ArrayList<SiteEntryImage>();


### PR DESCRIPTION
## Why
Resolves #203 
Allows admins to approve site images with a specified image id.

## This PR
Changes the approval status of the image with the given id to `APPROVED` regardless of the previous status.
Credit to @nalinikantheti for doing all the programming

## Verification Steps
Tested on postman to make sure that uploaded images switch to `APPROVED` 
