### PR TITLE
Knot.get unapproved images

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -12,6 +12,7 @@ import com.codeforcommunity.dto.site.NameSiteEntryRequest;
 import com.codeforcommunity.dto.site.ParentAdoptSiteRequest;
 import com.codeforcommunity.dto.site.ParentRecordStewardshipRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
+import com.codeforcommunity.dto.site.SiteEntryImage;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import com.codeforcommunity.dto.site.UploadSiteImageRequest;
 import java.sql.Date;
@@ -107,4 +108,6 @@ public interface IProtectedSiteProcessor {
 
   /** Edits the site entry with the given entryId */
   void editSiteEntry(JWTData userData, int entryId, UpdateSiteRequest editSiteEntryRequest);
+
+  List<SiteEntryImage> getUnapprovedImages(JWTData userData);
 }

--- a/api/src/main/java/com/codeforcommunity/dto/site/SiteEntryImage.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/SiteEntryImage.java
@@ -20,7 +20,11 @@ public class SiteEntryImage {
   }
 
   public SiteEntryImage(
-      Integer imageId, String uploaderUsername, Integer uploaderId, Timestamp uploadedAt, String imageUrl) {
+      Integer imageId,
+      String uploaderUsername,
+      Integer uploaderId,
+      Timestamp uploadedAt,
+      String imageUrl) {
     this.imageId = imageId;
     this.uploaderUsername = uploaderUsername;
     this.uploaderId = uploaderId;

--- a/api/src/main/java/com/codeforcommunity/dto/site/SiteEntryImage.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/SiteEntryImage.java
@@ -8,6 +8,8 @@ public class SiteEntryImage {
   private final Integer imageId;
   private final String uploaderUsername;
 
+  private String approvalStatus;
+
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy")
   private final Timestamp uploadedAt;
 
@@ -22,6 +24,7 @@ public class SiteEntryImage {
     this.uploaderUsername = uploaderUsername;
     this.uploadedAt = uploadedAt;
     this.imageUrl = imageUrl;
+    this.approvalStatus = "Unapproved";
   }
 
   public Integer getImageId() {
@@ -38,5 +41,9 @@ public class SiteEntryImage {
 
   public String getImageUrl() {
     return imageUrl;
+  }
+
+  public String getApprovalStatus(){
+    return this.approvalStatus;
   }
 }

--- a/api/src/main/java/com/codeforcommunity/dto/site/SiteEntryImage.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/SiteEntryImage.java
@@ -8,8 +8,6 @@ public class SiteEntryImage {
   private final Integer imageId;
   private final String uploaderUsername;
 
-  private String approvalStatus;
-
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy")
   private final Timestamp uploadedAt;
 
@@ -24,7 +22,6 @@ public class SiteEntryImage {
     this.uploaderUsername = uploaderUsername;
     this.uploadedAt = uploadedAt;
     this.imageUrl = imageUrl;
-    this.approvalStatus = "Unapproved";
   }
 
   public Integer getImageId() {
@@ -41,9 +38,5 @@ public class SiteEntryImage {
 
   public String getImageUrl() {
     return imageUrl;
-  }
-
-  public String getApprovalStatus(){
-    return this.approvalStatus;
   }
 }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -63,7 +63,8 @@ public class ProtectedSiteRouter implements IRouter {
     registerDeleteSiteImage(router);
     registerFilterSites(router);
     registerEditSiteEntry(router);
-
+    registerApproveSiteImage(router);
+    registerGetUnapprovedImages(router);
     return router;
   }
 
@@ -401,4 +402,31 @@ public class ProtectedSiteRouter implements IRouter {
 
     end(ctx.response(), 200);
   }
+
+  private void registerApproveSiteImage(Router router) {
+    Route approveSiteImage = router.put("/approve_image/:image_id");
+    approveSiteImage.handler(this::handleApproveSiteImage);
+  }
+
+  private void handleApproveSiteImage(RoutingContext ctx) {
+    JWTData userData = ctx.get("jwt_data");
+    int imageID = RestFunctions.getRequestParameterAsInt(ctx.request(), "image_id");
+
+    processor.approveSiteImage(userData, imageID);
+
+    end(ctx.response(), 200);
+  }
+
+
+  private void registerGetUnapprovedImages(Router router) {
+    Route unapprovedSiteImages = router.get("/unapproved_images");
+    unapprovedSiteImages.handler(this::handleGetUnapprovedImages);
+  }
+
+  private void handleGetUnapprovedImages(RoutingContext ctx) {
+    JWTData userData = ctx.get("jwt_data");
+    processor.getUnapprovedImages(userData);
+    end(ctx.response(), 200);
+  }
+
 }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -425,10 +425,8 @@ public class ProtectedSiteRouter implements IRouter {
   private void handleGetUnapprovedImages(RoutingContext ctx) {
     JWTData userData = ctx.get("jwt_data");
     List<SiteEntryImage> images = processor.getUnapprovedImages(userData);
-    List<JsonObject> jsonImages = images.stream()
-            .map(i -> JsonObject.mapFrom(i)).collect(Collectors.toList());
     end(ctx.response(), 200,
-            JsonObject.mapFrom(Collections.singletonMap("images", jsonImages))
+            JsonObject.mapFrom(Collections.singletonMap("images", images))
             .toString());
   }
 }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -15,6 +15,7 @@ import com.codeforcommunity.dto.site.NameSiteEntryRequest;
 import com.codeforcommunity.dto.site.ParentAdoptSiteRequest;
 import com.codeforcommunity.dto.site.ParentRecordStewardshipRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
+import com.codeforcommunity.dto.site.SiteEntryImage;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import com.codeforcommunity.dto.site.UploadSiteImageRequest;
 import com.codeforcommunity.rest.IRouter;
@@ -423,7 +424,11 @@ public class ProtectedSiteRouter implements IRouter {
 
   private void handleGetUnapprovedImages(RoutingContext ctx) {
     JWTData userData = ctx.get("jwt_data");
-    processor.getUnapprovedImages(userData);
-    end(ctx.response(), 200);
+    List<SiteEntryImage> images = processor.getUnapprovedImages(userData);
+    List<JsonObject> jsonImages = images.stream()
+            .map(i -> JsonObject.mapFrom(i)).collect(Collectors.toList());
+    end(ctx.response(), 200,
+            JsonObject.mapFrom(Collections.singletonMap("images", jsonImages))
+            .toString());
   }
 }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -417,6 +417,7 @@ public class ProtectedSiteRouter implements IRouter {
 
     end(ctx.response(), 200);
   }
+
   private void registerGetUnapprovedImages(Router router) {
     Route unapprovedSiteImages = router.get("/unapproved_images");
     unapprovedSiteImages.handler(this::handleGetUnapprovedImages);
@@ -425,8 +426,9 @@ public class ProtectedSiteRouter implements IRouter {
   private void handleGetUnapprovedImages(RoutingContext ctx) {
     JWTData userData = ctx.get("jwt_data");
     List<SiteEntryImage> images = processor.getUnapprovedImages(userData);
-    end(ctx.response(), 200,
-            JsonObject.mapFrom(Collections.singletonMap("images", images))
-            .toString());
+    end(
+        ctx.response(),
+        200,
+        JsonObject.mapFrom(Collections.singletonMap("images", images)).toString());
   }
 }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/SiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/SiteRouter.java
@@ -5,7 +5,6 @@ import static com.codeforcommunity.rest.ApiRouter.end;
 import com.codeforcommunity.api.ISiteProcessor;
 import com.codeforcommunity.dto.site.GetSiteResponse;
 import com.codeforcommunity.dto.site.StewardshipActivitiesResponse;
-import com.codeforcommunity.dto.site.StewardshipActivity;
 import com.codeforcommunity.dto.site.TreeBenefitsResponse;
 import com.codeforcommunity.logger.SLogger;
 import com.codeforcommunity.rest.IRouter;
@@ -64,11 +63,12 @@ public class SiteRouter implements IRouter {
     StewardshipActivitiesResponse stewardshipActivitiesResponse =
         processor.getStewardshipActivities(siteId);
 
-//    for (StewardshipActivity activity : stewardshipActivitiesResponse.getStewardshipActivities()) {
-//      logger.info("Date: " + activity.getDate().toString());
-//    }
+    //    for (StewardshipActivity activity :
+    // stewardshipActivitiesResponse.getStewardshipActivities()) {
+    //      logger.info("Date: " + activity.getDate().toString());
+    //    }
 
-//    logger.info(JsonObject.mapFrom(stewardshipActivitiesResponse).toString());
+    //    logger.info(JsonObject.mapFrom(stewardshipActivitiesResponse).toString());
 
     end(ctx.response(), 200, JsonObject.mapFrom(stewardshipActivitiesResponse).toString());
   }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
@@ -24,9 +24,7 @@ public class ProtectedEmailerProcessorImpl extends AbstractProcessor
   public void addTemplate(JWTData userData, AddTemplateRequest addTemplateRequest) {
     assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
     S3Requester.uploadHTML(
-        addTemplateRequest.getName(),
-        userData.getUserId(),
-        addTemplateRequest.getTemplate());
+        addTemplateRequest.getName(), userData.getUserId(), addTemplateRequest.getTemplate());
   }
 
   @Override

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -878,7 +878,7 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
   @Override
   public List<SiteEntryImage> getUnapprovedImages(JWTData userData) {
     assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
-    List<SiteImagesRecord> imageRecords = db.selectFrom(SITE_IMAGES).where(SITE_IMAGES.APPROVAL_STATUS.eq("Unapproved"));
+    List<SiteImagesRecord> imageRecords = db.selectFrom(SITE_IMAGES).where(SITE_IMAGES.APPROVAL_STATUS.eq(ImageApprovalStatus.SUBMITTED));
     List<SiteEntryImage> unapprovedImages = imageRecords.stream().map(
             imageRecord ->
                     new SiteEntryImage(

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -887,12 +887,17 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
             imageRecord ->
                     new SiteEntryImage(
                             imageRecord.getId(),
-                            db.selectFrom(USERS)
-                                    .where(USERS.ID.eq(imageRecord.getUploaderId()))
-                                    .fetchOne(USERS.USERNAME),
+                            this.getImageUploader(imageRecord),
                             imageRecord.getUploadedAt(),
                             imageRecord.getImageUrl())).collect(Collectors.toList());
     return unapprovedImages;
+  }
+
+  private String getImageUploader(SiteImagesRecord imageRecord) {
+    String username = db.selectFrom(USERS)
+            .where(USERS.ID.eq(imageRecord.getUploaderId()))
+            .fetchOne(USERS.USERNAME);
+    return username;
   }
 
   public void approveSiteImage(JWTData userData, int imageID) {

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -882,7 +882,7 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
     assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
     List<SiteImagesRecord> imageRecords =
             db.selectFrom(SITE_IMAGES).where(
-                    SITE_IMAGES.APPROVAL_STATUS.eq(ImageApprovalStatus.SUBMITTED)).fetch();
+                    SITE_IMAGES.APPROVAL_STATUS.eq(ImageApprovalStatus.SUBMITTED.getApprovalStatus())).fetch();
     List<SiteEntryImage> unapprovedImages = imageRecords.stream().map(
             imageRecord ->
                     new SiteEntryImage(

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -880,15 +880,20 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
 
   public List<SiteEntryImage> getUnapprovedImages(JWTData userData) {
     assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
-    List<SiteImagesRecord> imageRecords = db.selectFrom(SITE_IMAGES).where(SITE_IMAGES.APPROVAL_STATUS.eq(ImageApprovalStatus.SUBMITTED));
+    List<SiteImagesRecord> imageRecords =
+            db.selectFrom(SITE_IMAGES).where(
+                    SITE_IMAGES.APPROVAL_STATUS.eq("SUBMITTED")).fetch();
+    //System.out.println(imageRecords);
     List<SiteEntryImage> unapprovedImages = imageRecords.stream().map(
             imageRecord ->
                     new SiteEntryImage(
-                            imageRecord.getImageId(),
-                            imageRecord.getUploaderUsername(),
+                            imageRecord.getId(),
+                            db.selectFrom(USERS)
+                                    .where(USERS.ID.eq(imageRecord.getUploaderId()))
+                                    .fetchOne(USERS.USERNAME),
                             imageRecord.getUploadedAt(),
-                            imageRecord.getImageURL(),
-                            imageRecord.getApprovalStatus())).collect(Collectors.toList());
+                            imageRecord.getImageUrl())).collect(Collectors.toList());
+    System.out.println(unapprovedImages);
     return unapprovedImages;
   }
 

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -882,8 +882,7 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
     assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
     List<SiteImagesRecord> imageRecords =
             db.selectFrom(SITE_IMAGES).where(
-                    SITE_IMAGES.APPROVAL_STATUS.eq("SUBMITTED")).fetch();
-    //System.out.println(imageRecords);
+                    SITE_IMAGES.APPROVAL_STATUS.eq(ImageApprovalStatus.SUBMITTED)).fetch();
     List<SiteEntryImage> unapprovedImages = imageRecords.stream().map(
             imageRecord ->
                     new SiteEntryImage(
@@ -893,7 +892,6 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
                                     .fetchOne(USERS.USERNAME),
                             imageRecord.getUploadedAt(),
                             imageRecord.getImageUrl())).collect(Collectors.toList());
-    System.out.println(unapprovedImages);
     return unapprovedImages;
   }
 

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -877,24 +877,30 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
   }
 
   @Override
-
   public List<SiteEntryImage> getUnapprovedImages(JWTData userData) {
     assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
     List<SiteImagesRecord> imageRecords =
-            db.selectFrom(SITE_IMAGES).where(
-                    SITE_IMAGES.APPROVAL_STATUS.eq(ImageApprovalStatus.SUBMITTED.getApprovalStatus())).fetch();
-    List<SiteEntryImage> unapprovedImages = imageRecords.stream().map(
-            imageRecord ->
+        db.selectFrom(SITE_IMAGES)
+            .where(
+                SITE_IMAGES.APPROVAL_STATUS.eq(ImageApprovalStatus.SUBMITTED.getApprovalStatus()))
+            .fetch();
+    List<SiteEntryImage> unapprovedImages =
+        imageRecords.stream()
+            .map(
+                imageRecord ->
                     new SiteEntryImage(
-                            imageRecord.getId(),
-                            this.getImageUploader(imageRecord),
-                            imageRecord.getUploadedAt(),
-                            imageRecord.getImageUrl())).collect(Collectors.toList());
+                        imageRecord.getId(),
+                        this.getImageUploader(imageRecord),
+                        imageRecord.getUploaderId(),
+                        imageRecord.getUploadedAt(),
+                        imageRecord.getImageUrl()))
+            .collect(Collectors.toList());
     return unapprovedImages;
   }
 
   private String getImageUploader(SiteImagesRecord imageRecord) {
-    String username = db.selectFrom(USERS)
+    String username =
+        db.selectFrom(USERS)
             .where(USERS.ID.eq(imageRecord.getUploaderId()))
             .fetchOne(USERS.USERNAME);
     return username;

--- a/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
@@ -206,7 +206,11 @@ public class SiteProcessorImpl implements ISiteProcessor {
                 }
 
                 return new SiteEntryImage(
-                    record.getId(), username, record.getUploaderId(), record.getUploadedAt(), record.getImageUrl());
+                    record.getId(),
+                    username,
+                    record.getUploaderId(),
+                    record.getUploadedAt(),
+                    record.getImageUrl());
               })
           .collect(Collectors.toList());
     }
@@ -270,7 +274,7 @@ public class SiteProcessorImpl implements ISiteProcessor {
 
     records.forEach(
         record -> {
-//          logger.info("Stewardship activity recorded on: " + record.getPerformedOn());
+          //          logger.info("Stewardship activity recorded on: " + record.getPerformedOn());
 
           StewardshipActivity stewardshipActivity =
               new StewardshipActivity(
@@ -284,7 +288,7 @@ public class SiteProcessorImpl implements ISiteProcessor {
                   record.getInstalledWateringBag());
           activities.add(stewardshipActivity);
 
-//          logger.info("Stewardship recorded on: " + stewardshipActivity.getDate());
+          //          logger.info("Stewardship recorded on: " + stewardshipActivity.getDate());
         });
 
     return new StewardshipActivitiesResponse(activities);
@@ -308,7 +312,8 @@ public class SiteProcessorImpl implements ISiteProcessor {
         db.selectFrom(SITE_ENTRIES)
             .where(SITE_ENTRIES.SITE_ID.eq(siteId))
             .orderBy(SITE_ENTRIES.CREATED_AT.desc())
-            .fetchInto(SiteEntriesRecord.class).get(0);
+            .fetchInto(SiteEntriesRecord.class)
+            .get(0);
 
     if (record == null) {
       throw new ResourceDoesNotExistException(siteId, "site entry");

--- a/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
+++ b/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
@@ -79,8 +79,6 @@ public class S3Requester {
     externs = customExterns;
   }
 
-
-
   /**
    * Validates whether or not the given String is a base64 encoded image in the following format:
    * data:image/{extension};base64,{imageData}.
@@ -251,8 +249,7 @@ public class S3Requester {
    * @throws BadRequestHTMLException if the string to HTML decoding failed.
    * @throws S3FailedUploadException if the upload to S3 failed.
    */
-  public static String uploadHTML(
-      String name, Integer adminID, String htmlContent) {
+  public static String uploadHTML(String name, Integer adminID, String htmlContent) {
     // Save HTML to temp file
     String fullFileName = getFileNameWithoutExtension(name, TEMPLATE_FILE_EXTENSION);
     File tempFile;
@@ -305,7 +302,8 @@ public class S3Requester {
     // Delete the temporary file that was written to disk
     tempFile.delete();
 
-    return String.join("/", externs.getBucketPublicUrl(), TEMPLATE_S3_DIR, externs.getDirPublic(), name);
+    return String.join(
+        "/", externs.getBucketPublicUrl(), TEMPLATE_S3_DIR, externs.getDirPublic(), name);
   }
 
   // helper to check whether the given path exists
@@ -323,8 +321,8 @@ public class S3Requester {
    * @throws SdkClientException if the loading from S3 failed.
    */
   public static LoadTemplateResponse loadHTML(String name) {
-    String htmlPath = String.join("/",
-        TEMPLATE_S3_DIR, externs.getDirPublic(), name + TEMPLATE_FILE_EXTENSION);
+    String htmlPath =
+        String.join("/", TEMPLATE_S3_DIR, externs.getDirPublic(), name + TEMPLATE_FILE_EXTENSION);
 
     if (!pathExists(htmlPath)) {
       throw new InvalidURLException();
@@ -359,8 +357,8 @@ public class S3Requester {
    * @throws SdkClientException if the deletion from S3 failed.
    */
   public static void deleteHTML(String name) {
-    String htmlPath = String.join("/",
-        TEMPLATE_S3_DIR, externs.getDirPublic(), name + TEMPLATE_FILE_EXTENSION);
+    String htmlPath =
+        String.join("/", TEMPLATE_S3_DIR, externs.getDirPublic(), name + TEMPLATE_FILE_EXTENSION);
 
     if (!pathExists(htmlPath)) {
       throw new InvalidURLException();

--- a/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
+++ b/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
@@ -79,6 +79,8 @@ public class S3Requester {
     externs = customExterns;
   }
 
+
+
   /**
    * Validates whether or not the given String is a base64 encoded image in the following format:
    * data:image/{extension};base64,{imageData}.

--- a/service/src/main/java/com/codeforcommunity/requester/TreeBenefitsCalculator.java
+++ b/service/src/main/java/com/codeforcommunity/requester/TreeBenefitsCalculator.java
@@ -1,12 +1,11 @@
 package com.codeforcommunity.requester;
 
-import com.codeforcommunity.dto.site.TreeBenefitsResponse;
-
 import static org.jooq.generated.Tables.TREE_BENEFITS;
 import static org.jooq.generated.Tables.TREE_SPECIES;
 import static org.jooq.impl.DSL.lower;
 import static org.jooq.impl.DSL.replace;
 
+import com.codeforcommunity.dto.site.TreeBenefitsResponse;
 import java.util.HashMap;
 import java.util.Map;
 import org.jooq.DSLContext;


### PR DESCRIPTION
## Why

Resolves #202

adds a way for devs to get all unapproved images

## This PR

retrieves all images from SITE_IMAGES table with SUBMITTED approval status, so adding another enum in the future may break

## Verification Steps

postman check for http://localhost:8081/api/v1/protected/sites/unapproved_images