### PR TITLE
Ah.site reporting edit

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/site/ReportSiteRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/ReportSiteRequest.java
@@ -41,10 +41,6 @@ public class ReportSiteRequest extends ApiDto {
       fields.add(fieldName + "reason");
     }
 
-    if (description == null) {
-      fields.add(fieldName + "description");
-    }
-
     return fields;
   }
 }

--- a/service/src/main/java/com/codeforcommunity/requester/Emailer.java
+++ b/service/src/main/java/com/codeforcommunity/requester/Emailer.java
@@ -153,7 +153,7 @@ public class Emailer {
     templateValues.put("email", userEmail);
     templateValues.put("siteId", String.valueOf(siteId));
     templateValues.put("reportReason", reportReason);
-    templateValues.put("reportDescription", reportDescription);
+    templateValues.put("reportDescription", reportDescription == null ? "N/A" : reportDescription);
 
     Optional<String> emailBody = emailOperations.getTemplateString(filePath, templateValues);
     emailBody.ifPresent(

--- a/service/src/main/java/com/codeforcommunity/requester/Emailer.java
+++ b/service/src/main/java/com/codeforcommunity/requester/Emailer.java
@@ -148,12 +148,17 @@ public class Emailer {
       String reportDescription) {
     String filePath = "/emails/SiteIssueReport.html";
 
+    String description = reportDescription;
+    if (description == null || description.isEmpty()) {
+      description = "N/A";
+    }
+
     Map<String, String> templateValues = new HashMap<>();
     templateValues.put("name", userFullName);
     templateValues.put("email", userEmail);
     templateValues.put("siteId", String.valueOf(siteId));
     templateValues.put("reportReason", reportReason);
-    templateValues.put("reportDescription", reportDescription == null ? "N/A" : reportDescription);
+    templateValues.put("reportDescription", description);
 
     Optional<String> emailBody = emailOperations.getTemplateString(filePath, templateValues);
     emailBody.ifPresent(


### PR DESCRIPTION
## Why

Resolves #<ticket number here>

Minor tweak to site reporting route - makes the description optional, and uses a default description if none is given
Main PR: https://github.com/Code-4-Community/speak-for-the-trees-frontend/pull/355

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

## Verification Steps

Verified description gets replaced with default if not given:

![image](https://github.com/Code-4-Community/speak-for-the-trees-backend-v2/assets/68914997/b7294307-31a1-45f1-91c4-286db91f0c5e)


<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->
