### PR TITLE
Ot.rejected image

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -19,6 +19,9 @@ import com.codeforcommunity.dto.site.ReportSiteRequest;
 import com.codeforcommunity.dto.site.SiteEntryImage;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import com.codeforcommunity.dto.site.UploadSiteImageRequest;
+
+import org.simplejavamail.api.email.AttachmentResource;
+
 import java.sql.Date;
 import java.util.List;
 
@@ -138,4 +141,7 @@ public interface IProtectedSiteProcessor {
 
   /** Reports the site for an issue by sending an email to SFTT */
   void reportSiteForIssues(JWTData userData, int siteId, ReportSiteRequest reportSiteRequest);
+
+  /** Loads a site image with the given ID as an attachment resource*/
+  AttachmentResource loadSiteImage(JWTData userData, int imageId);
 }

--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -131,8 +131,8 @@ public interface IProtectedSiteProcessor {
   /** Edits the site entry with the given entryId */
   void editSiteEntry(JWTData userData, int entryId, UpdateSiteRequest editSiteEntryRequest);
 
-  /** Rejects the site image (deletes and optionally sends an email with a rejection reason
-   * to the uploader) with the given imageId */
+  /** Rejects the site image (deletes and sends an email with a rejection reason and the
+   * rejected image to the uploader's email) with the given imageId */
   void rejectSiteImage(JWTData userData, int imageId, String rejectionReason);
   List<SiteEntryImage> getUnapprovedImages(JWTData userData);
 

--- a/api/src/main/java/com/codeforcommunity/dto/emailer/EmailAttachment.java
+++ b/api/src/main/java/com/codeforcommunity/dto/emailer/EmailAttachment.java
@@ -24,7 +24,7 @@ public class EmailAttachment extends ApiDto {
 
     private EmailAttachment() {}
 
-    private static String getFileMimeType(String base64File) {
+    public static String getFileMimeType(String base64File) {
         if (base64File == null || base64File.length() < 10) {
             return null;
         }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -22,6 +22,7 @@ import com.codeforcommunity.dto.site.ReportSiteRequest;
 import com.codeforcommunity.dto.site.SiteEntryImage;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import com.codeforcommunity.dto.site.UploadSiteImageRequest;
+import com.codeforcommunity.exceptions.MissingParameterException;
 import com.codeforcommunity.rest.IRouter;
 import com.codeforcommunity.rest.RestFunctions;
 import io.vertx.core.Vertx;
@@ -416,7 +417,13 @@ public class ProtectedSiteRouter implements IRouter {
   private void handleRejectSiteImage(RoutingContext ctx) {
     JWTData userData = ctx.get("jwt_data");
     int imageId = RestFunctions.getRequestParameterAsInt(ctx.request(), "image_id");
-    String rejectionReason = RestFunctions.getRequestParameterAsString(ctx.request(), "reason");
+
+    String rejectionReason;
+    try {
+      rejectionReason = RestFunctions.getRequestParameterAsString(ctx.request(), "reason");
+    } catch (MissingParameterException e) {
+      rejectionReason = "Your image upload was rejected by an admin";
+    }
 
     processor.rejectSiteImage(userData, imageId, rejectionReason);
 

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class ProtectedSiteRouter implements IRouter {
@@ -417,15 +418,11 @@ public class ProtectedSiteRouter implements IRouter {
   private void handleRejectSiteImage(RoutingContext ctx) {
     JWTData userData = ctx.get("jwt_data");
     int imageId = RestFunctions.getRequestParameterAsInt(ctx.request(), "image_id");
+    String defaultRejectionReason = "Your image upload was rejected by an admin";
+    Optional<String> rejectionReason = RestFunctions.getOptionalQueryParam(
+            ctx, "reason", Function.identity());
 
-    String rejectionReason;
-    try {
-      rejectionReason = RestFunctions.getRequestParameterAsString(ctx.request(), "reason");
-    } catch (MissingParameterException e) {
-      rejectionReason = "Your image upload was rejected by an admin";
-    }
-
-    processor.rejectSiteImage(userData, imageId, rejectionReason);
+    processor.rejectSiteImage(userData, imageId, rejectionReason.orElse(defaultRejectionReason));
 
     end(ctx.response(), 200);
   }

--- a/common/src/main/java/com/codeforcommunity/email/EmailOperations.java
+++ b/common/src/main/java/com/codeforcommunity/email/EmailOperations.java
@@ -4,6 +4,7 @@ import com.codeforcommunity.logger.SLogger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -150,6 +151,34 @@ public class EmailOperations {
     }
   }
 
+  private Email buildEmailSingleRecipient(
+          String sendToName, String sendToEmail, String subject, String emailBody, List<AttachmentResource> attachments) {
+    Email email =
+            EmailBuilder.startingBlank()
+                    .from(senderName, sendEmail)
+                    .to(sendToName, sendToEmail)
+                    .withSubject(subject)
+                    .withHTMLText(emailBody)
+                    .withAttachments(attachments)
+                    .buildEmail();
+
+    return email;
+  }
+
+  /**
+   * Send an email with the given subject and body to the user with the given name at the given
+   * email with attachments.
+   */
+  public void sendEmailToOneRecipient(
+          String sendToName, String sendToEmail, String subject, String emailBody, List<AttachmentResource> attachments) {
+    if (!shouldSendEmails) {
+      return;
+    }
+    logger.info(String.format("Sending email with subject `%s`", subject));
+    Email email = buildEmailSingleRecipient(sendToName, sendToEmail, subject, emailBody, attachments);
+    this.sendEmail(email, subject);
+  }
+
   /**
    * Send an email with the given subject and body to the user with the given name at the given
    * email.
@@ -159,38 +188,44 @@ public class EmailOperations {
     if (!shouldSendEmails) {
       return;
     }
-
     logger.info(String.format("Sending email with subject `%s`", subject));
-
-    Email email =
-        EmailBuilder.startingBlank()
-            .from(senderName, sendEmail)
-            .to(sendToName, sendToEmail)
-            .withSubject(subject)
-            .withHTMLText(emailBody)
-            .buildEmail();
-
+    Email email = buildEmailSingleRecipient(sendToName, sendToEmail, subject, emailBody, new ArrayList<>());
     this.sendEmail(email, subject);
   }
 
-  /** Send an email with the given subject and body to the users with the given email addresses. */
+  private Email buildEmailMultipleRecipient(
+          HashSet<String> sendToEmails, String subject, String emailBody, List<AttachmentResource> attachments) {
+    Email email =
+            EmailBuilder.startingBlank()
+                    .from(senderName, sendEmail)
+                    .bccMultiple(sendToEmails.toArray(new String[0]))
+                    .withSubject(subject)
+                    .withHTMLText(emailBody)
+                    .withAttachments(attachments)
+                    .buildEmail();
+
+    return email;
+  }
+
+  /** Send an email with the given subject and body to the users with the given email addresses with attachments. */
   public void sendEmailToMultipleRecipients(
       HashSet<String> sendToEmails, String subject, String emailBody, List<AttachmentResource> attachments) {
     if (!shouldSendEmails) {
       return;
     }
-
     logger.info(String.format("Sending emails with subject `%s`", subject));
+    Email email = buildEmailMultipleRecipient(sendToEmails, subject, emailBody, attachments);
+    this.sendEmail(email, subject);
+  }
 
-    Email email =
-        EmailBuilder.startingBlank()
-            .from(senderName, sendEmail)
-            .bccMultiple(sendToEmails.toArray(new String[0]))
-            .withSubject(subject)
-            .withHTMLText(emailBody)
-            .withAttachments(attachments)
-            .buildEmail();
-
+  /** Send an email with the given subject and body to the users with the given email addresses. */
+  public void sendEmailToMultipleRecipients(
+          HashSet<String> sendToEmails, String subject, String emailBody) {
+    if (!shouldSendEmails) {
+      return;
+    }
+    logger.info(String.format("Sending emails with subject `%s`", subject));
+    Email email = buildEmailMultipleRecipient(sendToEmails, subject, emailBody, new ArrayList<>());
     this.sendEmail(email, subject);
   }
 }

--- a/common/src/main/java/com/codeforcommunity/email/EmailOperations.java
+++ b/common/src/main/java/com/codeforcommunity/email/EmailOperations.java
@@ -179,20 +179,6 @@ public class EmailOperations {
     this.sendEmail(email, subject);
   }
 
-  /**
-   * Send an email with the given subject and body to the user with the given name at the given
-   * email.
-   */
-  public void sendEmailToOneRecipient(
-      String sendToName, String sendToEmail, String subject, String emailBody) {
-    if (!shouldSendEmails) {
-      return;
-    }
-    logger.info(String.format("Sending email with subject `%s`", subject));
-    Email email = buildEmailSingleRecipient(sendToName, sendToEmail, subject, emailBody, new ArrayList<>());
-    this.sendEmail(email, subject);
-  }
-
   private Email buildEmailMultipleRecipient(
           HashSet<String> sendToEmails, String subject, String emailBody, List<AttachmentResource> attachments) {
     Email email =
@@ -215,17 +201,6 @@ public class EmailOperations {
     }
     logger.info(String.format("Sending emails with subject `%s`", subject));
     Email email = buildEmailMultipleRecipient(sendToEmails, subject, emailBody, attachments);
-    this.sendEmail(email, subject);
-  }
-
-  /** Send an email with the given subject and body to the users with the given email addresses. */
-  public void sendEmailToMultipleRecipients(
-          HashSet<String> sendToEmails, String subject, String emailBody) {
-    if (!shouldSendEmails) {
-      return;
-    }
-    logger.info(String.format("Sending emails with subject `%s`", subject));
-    Email email = buildEmailMultipleRecipient(sendToEmails, subject, emailBody, new ArrayList<>());
     this.sendEmail(email, subject);
   }
 }

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "speak-for-the-trees-backend-v2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -1,5 +1,6 @@
 package com.codeforcommunity.processor;
 
+import static com.codeforcommunity.requester.S3Requester.loadSiteImage;
 import static org.jooq.generated.Tables.ADOPTED_SITES;
 import static org.jooq.generated.Tables.BLOCKS;
 import static org.jooq.generated.Tables.NEIGHBORHOODS;
@@ -80,6 +81,7 @@ import org.jooq.generated.tables.records.StewardshipRecord;
 import org.jooq.generated.tables.records.UserSiteReportsRecord;
 import org.jooq.generated.tables.records.UsersRecord;
 import org.jooq.generated.tables.pojos.Users;
+import org.simplejavamail.api.email.AttachmentResource;
 
 public class ProtectedSiteProcessorImpl extends AbstractProcessor
     implements IProtectedSiteProcessor {
@@ -744,6 +746,18 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
     db.deleteFrom(SITE_IMAGES).where(SITE_IMAGES.ID.eq(imageId)).execute();
   }
 
+  @Override AttachmentResource loadSiteImage(JWTData userData, int imageId) {
+    checkAdminOrImageUploader(userData, imageId);
+    checkImageExists(imageId);
+
+    String imageUrl =
+            db.select(SITE_IMAGES.IMAGE_URL)
+                    .from(SITE_IMAGES)
+                    .where(SITE_IMAGES.ID.eq(imageId))
+                    .fetchOne(SITE_IMAGES.IMAGE_URL, String.class);
+    return new AttachmentResource(imageUrl, loadS3Image(imageUrl));
+  }
+
   @Override
   public List<FilterSitesResponse> filterSites(
       JWTData userData, FilterSitesRequest filterSitesRequest) {
@@ -1049,7 +1063,8 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
       String userEmail = user.getEmail();
       String userFullName =
               AuthDatabaseOperations.getFullName(user.into(Users.class));
-      emailer.sendRejectImageEmail(userEmail, userFullName, reason);
+      AttachmentResource image = loadSiteImage(userData, imageId);
+      emailer.sendRejectImageEmail(userEmail, userFullName, reason, image);
       deleteSiteImage(userData, imageId);
     } else {
       throw new IllegalStateException("Cannot reject an already approved image");

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -1,5 +1,6 @@
 package com.codeforcommunity.processor;
 
+import static com.codeforcommunity.requester.S3Requester.loadS3Image;
 import static com.codeforcommunity.requester.S3Requester.loadSiteImage;
 import static org.jooq.generated.Tables.ADOPTED_SITES;
 import static org.jooq.generated.Tables.BLOCKS;

--- a/service/src/main/java/com/codeforcommunity/requester/Emailer.java
+++ b/service/src/main/java/com/codeforcommunity/requester/Emailer.java
@@ -58,7 +58,7 @@ public class Emailer {
     Optional<String> emailBody = emailOperations.getTemplateString(filePath, templateValues);
 
     emailBody.ifPresent(
-        s -> emailOperations.sendEmailToOneRecipient(sendToName, sendToEmail, subjectWelcome, s));
+        s -> emailOperations.sendEmailToOneRecipient(sendToName, sendToEmail, subjectWelcome, s, new ArrayList<>()));
   }
 
   public void sendEmailChangeConfirmationEmail(
@@ -72,7 +72,7 @@ public class Emailer {
     emailBody.ifPresent(
         s ->
             emailOperations.sendEmailToOneRecipient(
-                sendToName, sendToEmail, subjectEmailChange, s));
+                sendToName, sendToEmail, subjectEmailChange, s, new ArrayList<>()));
   }
 
   public void sendPasswordChangeRequestEmail(
@@ -86,7 +86,7 @@ public class Emailer {
     emailBody.ifPresent(
         s ->
             emailOperations.sendEmailToOneRecipient(
-                sendToName, sendToEmail, subjectPasswordResetRequest, s));
+                sendToName, sendToEmail, subjectPasswordResetRequest, s, new ArrayList<>()));
   }
 
   public void sendPasswordChangeConfirmationEmail(String sendToEmail, String sendToName) {
@@ -98,7 +98,7 @@ public class Emailer {
     emailBody.ifPresent(
         s ->
             emailOperations.sendEmailToOneRecipient(
-                sendToName, sendToEmail, subjectPasswordResetConfirm, s));
+                sendToName, sendToEmail, subjectPasswordResetConfirm, s, new ArrayList<>()));
   }
 
   public void sendAccountDeactivatedEmail(String sendToEmail, String sendToName) {
@@ -110,7 +110,7 @@ public class Emailer {
     emailBody.ifPresent(
         s ->
             emailOperations.sendEmailToOneRecipient(
-                sendToName, sendToEmail, subjectAccountDeleted, s));
+                sendToName, sendToEmail, subjectAccountDeleted, s, new ArrayList<>()));
   }
 
   public void sendInviteTeamEmail(String sendToEmail, String sendToName, String teamName) {
@@ -123,7 +123,7 @@ public class Emailer {
     emailBody.ifPresent(
         s ->
             emailOperations.sendEmailToOneRecipient(
-                sendToName, sendToEmail, subjectAccountDeleted, s));
+                sendToName, sendToEmail, subjectAccountDeleted, s, new ArrayList<>()));
     // TODO implement this
   }
 
@@ -164,7 +164,7 @@ public class Emailer {
     emailBody.ifPresent(
         s ->
             emailOperations.sendEmailToOneRecipient(
-                senderName, reportEmailDestination, subjectSiteReport, s));
+                senderName, reportEmailDestination, subjectSiteReport, s, new ArrayList<>()));
   }
 
   public void sendArbitraryEmail(HashSet<String> sendToEmails, String subject, String body,

--- a/service/src/main/java/com/codeforcommunity/requester/Emailer.java
+++ b/service/src/main/java/com/codeforcommunity/requester/Emailer.java
@@ -127,17 +127,17 @@ public class Emailer {
     // TODO implement this
   }
 
-  public void sendRejectImageEmail(String sendToEmail, String sendToName, String reason) {
+  public void sendRejectImageEmail(String sendToEmail, String sendToName, String reason, AttachmentResource rejectedImage) {
     String filePath = "/emails/RejectImageEmail.html";
 
     Map<String, String> templateValues = new HashMap<>();
     templateValues.put("reason", reason);
     Optional<String> emailBody = emailOperations.getTemplateString(filePath, templateValues);
-
+    List<AttachmentResource> attachments = Arrays.asList(rejectedImage);
     emailBody.ifPresent(
             s ->
                     emailOperations.sendEmailToOneRecipient(
-                            sendToName, sendToEmail, subjectImageRejected, s));
+                            sendToName, sendToEmail, subjectImageRejected, s, attachments));
   }
 
   public void sendIssueReportEmail(

--- a/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
+++ b/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
@@ -248,7 +248,7 @@ public class S3Requester {
    * @param imageUrl the URL of the image file in S3 to delete.
    * @throws SdkClientException if the load from S3 failed.
    */
-  public static AttachmentResource loadS3Image(String imageUrl) {
+  public static S3Object loadS3Image(String imageUrl) {
     String imagePath = imageUrl.split(externs.getBucketPublicUrl() + '/')[1];
 
     if (!pathExists(imagePath)) {
@@ -259,18 +259,7 @@ public class S3Requester {
     GetObjectRequest awsRequest = new GetObjectRequest(externs.getBucketPublic(), imagePath);
 
     S3Object image = externs.getS3Client().getObject(awsRequest);
-    S3ObjectInputStream is = image.getObjectContent();
-
-    String mimeType = "img/" + image.getObjectMetadata().getContentType();
-    DataSource datasource;
-    try {
-      datasource = new ByteArrayDataSource(is, mimeType);
-    } catch (IOException e) {
-      throw new MalformedParameterException("Image encoding is incompatible");
-    }
-
-    String name = image.getKey();
-    return new AttachmentResource(name, datasource);
+    return image;
   }
 
   /**

--- a/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
+++ b/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
@@ -264,11 +264,18 @@ public class S3Requester {
     }
 
     String imageContent = content.toString();
-    //#String mimeType =
-    //String htmlAuthor = image.getObjectMetadata().getUserMetaDataOf("userID");
-
-    return new FileDataSource();
-    };
+    try {
+      File tempFile = File.createTempFile("reject_image_tmp", null, null);
+      FileOutputStream fos = new FileOutputStream(tempFile);
+      byte[] bytesArray = imageContent.getBytes();
+      fos.write(bytesArray);
+      fos.flush();
+      fos.close();
+      return new FileDataSource(tempFile);
+    } catch (IllegalArgumentException | IOException e) {
+      // The string failed to decode to HTML
+      throw new BadRequestHTMLException("HTML could not be written to disk.");
+    }
   }
 
   /**

--- a/service/target 2/surefire-reports/com.codeforcommunity.processor.ReservationProcessorImplTest.txt
+++ b/service/target 2/surefire-reports/com.codeforcommunity.processor.ReservationProcessorImplTest.txt
@@ -1,0 +1,4 @@
+-------------------------------------------------------------------------------
+Test set: com.codeforcommunity.processor.ReservationProcessorImplTest
+-------------------------------------------------------------------------------
+Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.673 s - in com.codeforcommunity.processor.ReservationProcessorImplTest


### PR DESCRIPTION
## Why

Resolves #228 

Attaches the rejected image to the rejection email sent.

## This PR
Directly passes the s3objectInputStream to a ByteArrayDataSource to construct an AttachmentResource.

Abstracts some email construction in EmailOperations.java for single and multiple recipient emails into helpers to allow for optional email attachments.

Also makes a rejection reason optional after #231 

## Verification Steps
Ensured that rejecting both jpeg and png image correctly attaches in the email
