### PR TITLE
Implement Site Entry Deleting

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -128,9 +128,12 @@ public interface IProtectedSiteProcessor {
   /** Edits the site entry with the given entryId */
   void editSiteEntry(JWTData userData, int entryId, UpdateSiteRequest editSiteEntryRequest);
 
-  /** Rejects the site image (deletes and optionally sends an email with a rejection reason
-   * to the uploader) with the given imageId */
+  /**
+   * Rejects the site image (deletes and optionally sends an email with a rejection reason to the
+   * uploader) with the given imageId
+   */
   void rejectSiteImage(JWTData userData, int imageId, String rejectionReason);
+
   List<SiteEntryImage> getUnapprovedImages(JWTData userData);
 
   /** Allows Admin users to approve uploaded site images of the given ID */
@@ -138,4 +141,7 @@ public interface IProtectedSiteProcessor {
 
   /** Reports the site for an issue by sending an email to SFTT */
   void reportSiteForIssues(JWTData userData, int siteId, ReportSiteRequest reportSiteRequest);
+
+  /** Deletes the given site entry and associated data */
+  void deleteSiteEntry(JWTData userData, int entryId);
 }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -17,7 +17,6 @@ import com.codeforcommunity.dto.site.NameSiteEntryRequest;
 import com.codeforcommunity.dto.site.ParentAdoptSiteRequest;
 import com.codeforcommunity.dto.site.ParentRecordStewardshipRequest;
 import com.codeforcommunity.dto.site.RecordStewardshipRequest;
-import com.codeforcommunity.dto.site.RejectImageRequest;
 import com.codeforcommunity.dto.site.ReportSiteRequest;
 import com.codeforcommunity.dto.site.SiteEntryImage;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
@@ -73,6 +72,7 @@ public class ProtectedSiteRouter implements IRouter {
     registerApproveSiteImage(router);
     registerGetUnapprovedImages(router);
     registerReportSiteIssue(router);
+    registerDeleteSiteEntry(router);
     return router;
   }
 
@@ -364,9 +364,7 @@ public class ProtectedSiteRouter implements IRouter {
         RestFunctions.getOptionalQueryParam(ctx, "lastActivityEnd", Date::valueOf);
     Optional<List<Integer>> neighborhoodIds =
         RestFunctions.getOptionalQueryParam(
-            ctx,
-            "neighborhoodIds",
-            this::parseOptionalQueryParamList);
+            ctx, "neighborhoodIds", this::parseOptionalQueryParamList);
     Optional<Integer> activityCountMax =
         RestFunctions.getOptionalQueryParam(ctx, "activityCountMax", Integer::parseInt);
 
@@ -446,19 +444,16 @@ public class ProtectedSiteRouter implements IRouter {
     JWTData userData = ctx.get("jwt_data");
 
     Optional<Timestamp> submittedStart =
-        RestFunctions.getOptionalQueryParam(ctx, "submittedStart", (date) -> new Timestamp(Date.valueOf(date).getTime()));
-    Optional<Timestamp> submittedEnd =
-        RestFunctions.getOptionalQueryParam(ctx, "submittedEnd", (date) -> new Timestamp(Date.valueOf(date).getTime()));
-    Optional<List<Integer>> siteIds =
         RestFunctions.getOptionalQueryParam(
-            ctx,
-            "siteIds",
-            this::parseOptionalQueryParamList);
+            ctx, "submittedStart", (date) -> new Timestamp(Date.valueOf(date).getTime()));
+    Optional<Timestamp> submittedEnd =
+        RestFunctions.getOptionalQueryParam(
+            ctx, "submittedEnd", (date) -> new Timestamp(Date.valueOf(date).getTime()));
+    Optional<List<Integer>> siteIds =
+        RestFunctions.getOptionalQueryParam(ctx, "siteIds", this::parseOptionalQueryParamList);
     Optional<List<Integer>> neighborhoodIds =
         RestFunctions.getOptionalQueryParam(
-            ctx,
-            "neighborhoodIds",
-            this::parseOptionalQueryParamList);
+            ctx, "neighborhoodIds", this::parseOptionalQueryParamList);
     FilterSiteImageRequest filterSiteImageRequest =
         new FilterSiteImageRequest(
             submittedStart.orElse(null),
@@ -498,6 +493,20 @@ public class ProtectedSiteRouter implements IRouter {
         RestFunctions.getJsonBodyAsClass(ctx, ReportSiteRequest.class);
 
     processor.reportSiteForIssues(userData, siteId, reportSiteRequest);
+
+    end(ctx.response(), 200);
+  }
+
+  private void registerDeleteSiteEntry(Router router) {
+    Route deleteSiteEntry = router.delete("/delete_entry/:entry_id");
+    deleteSiteEntry.handler(this::handleDeleteSiteEntry);
+  }
+
+  private void handleDeleteSiteEntry(RoutingContext ctx) {
+    int entryId = RestFunctions.getRequestParameterAsInt(ctx.request(), "entry_id");
+    JWTData userData = ctx.get("jwt_data");
+
+    processor.deleteSiteEntry(userData, entryId);
 
     end(ctx.response(), 200);
   }

--- a/persist/src/main/resources/db/migration/V6_1__AddEntryDeletedAt.sql
+++ b/persist/src/main/resources/db/migration/V6_1__AddEntryDeletedAt.sql
@@ -1,0 +1,1 @@
+ALTER TABLE site_entries ADD COLUMN deleted_at TIMESTAMP DEFAULT NULL;

--- a/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
@@ -194,6 +194,7 @@ public class MapProcessorImpl implements IMapProcessor {
                     this.db
                         .select(SITE_ENTRIES.SITE_ID, maxDate)
                         .from(SITE_ENTRIES)
+                        .where(SITE_ENTRIES.DELETED_AT.isNull())
                         .groupBy(SITE_ENTRIES.SITE_ID))
                 .as("recentlyCreated");
 

--- a/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
@@ -294,7 +294,7 @@ public class MapProcessorImpl implements IMapProcessor {
   private static class SiteGeoResponseCache {
     private static SiteGeoResponse response;
     private static long expireTime = 0;
-    private static final long timeToLive = 1 * 60 * 1000; // in milliseconds, 5000 is the avg. response time
+    private static final long timeToLive = 30 * 1000; // in milliseconds, 5000 is the avg. response time
 
     public static SiteGeoResponse getResponse() {
       return response;

--- a/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
@@ -295,7 +295,7 @@ public class MapProcessorImpl implements IMapProcessor {
   private static class SiteGeoResponseCache {
     private static SiteGeoResponse response;
     private static long expireTime = 0;
-    private static final long timeToLive = 30 * 1000; // in milliseconds, 5000 is the avg. response time
+    private static final long timeToLive = 20 * 1000; // in milliseconds, 5000 is the avg. response time
 
     public static SiteGeoResponse getResponse() {
       return response;

--- a/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
@@ -273,6 +273,7 @@ public class MapProcessorImpl implements IMapProcessor {
                 .on(SITES.ID.eq(newEntries.field(SITE_ENTRIES.SITE_ID)))
                 .leftJoin(ADOPTED_SITES)
                 .on(ADOPTED_SITES.SITE_ID.eq(SITES.ID))
+                .where(SITES.DELETED_AT.isNull())
                 .orderBy(SITES.ID)
                 .fetch();
 
@@ -293,7 +294,7 @@ public class MapProcessorImpl implements IMapProcessor {
   private static class SiteGeoResponseCache {
     private static SiteGeoResponse response;
     private static long expireTime = 0;
-    private static final long timeToLive = 10000; // in milliseconds, 5000 is the avg. response time
+    private static final long timeToLive = 1 * 60 * 1000; // in milliseconds, 5000 is the avg. response time
 
     public static SiteGeoResponse getResponse() {
       return response;

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -106,7 +106,7 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
     if (!db.fetchExists(db.selectFrom(SITES).where(SITES.ID.eq(siteId)))) {
       throw new ResourceDoesNotExistException(siteId, "Site");
     }
-  }
+  } 
 
   /**
    * Check if an entry with the given entryId exists.

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedSiteProcessorImpl.java
@@ -2,6 +2,7 @@ package com.codeforcommunity.processor;
 
 import static org.jooq.generated.Tables.ADOPTED_SITES;
 import static org.jooq.generated.Tables.BLOCKS;
+import static org.jooq.generated.Tables.ENTRY_USERNAMES;
 import static org.jooq.generated.Tables.NEIGHBORHOODS;
 import static org.jooq.generated.Tables.PARENT_ACCOUNTS;
 import static org.jooq.generated.Tables.SITES;
@@ -15,12 +16,10 @@ import static org.jooq.impl.DSL.count;
 import static org.jooq.impl.DSL.max;
 import static org.jooq.impl.DSL.noCondition;
 import static org.jooq.impl.DSL.when;
-import static org.jooq.impl.DSL.withRecursive;
 
 import com.codeforcommunity.api.IProtectedSiteProcessor;
 import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dataaccess.AuthDatabaseOperations;
-import com.codeforcommunity.dto.site.*;
 import com.codeforcommunity.dto.site.AddSiteRequest;
 import com.codeforcommunity.dto.site.AddSitesRequest;
 import com.codeforcommunity.dto.site.AdoptedSitesResponse;
@@ -61,12 +60,11 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
+import org.jooq.Record2;
 import org.jooq.Record3;
 import org.jooq.Record11;
 import org.jooq.Result;
@@ -1080,5 +1078,21 @@ public class ProtectedSiteProcessorImpl extends AbstractProcessor
     record.setUserId(userData.getUserId());
     record.setCreatedAt(Timestamp.valueOf(LocalDateTime.now()));
     record.store();
+  }
+
+  @Override
+  public void deleteSiteEntry(JWTData userData, int entryId) {
+    assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
+    checkEntryExists(entryId);
+
+    SiteEntriesRecord entry = db.selectFrom(SITE_ENTRIES).where(SITE_ENTRIES.ID.eq(entryId)).fetchOne();
+    int count = db.selectCount().from(SITE_ENTRIES).where(SITE_ENTRIES.SITE_ID.eq(entry.getSiteId())).fetchOne(0, int.class);
+
+    if (count <= 1) {
+      throw new ForbiddenException("Must have at least one other site entry");
+    }
+
+    entry.setDeletedAt(new Timestamp(System.currentTimeMillis()));
+    entry.store();
   }
 }

--- a/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
@@ -255,7 +255,8 @@ public class SiteProcessorImpl implements ISiteProcessor {
 
   @Override
   public GetSiteResponse getSite(int siteId) {
-    SitesRecord sitesRecord = db.selectFrom(SITES).where(SITES.ID.eq(siteId)).fetchOne();
+    SitesRecord sitesRecord = db.selectFrom(SITES).where(SITES.ID.eq(siteId))
+            .and(SITES.DELETED_AT.isNull()).fetchOne();
 
     if (sitesRecord == null) {
       throw new ResourceDoesNotExistException(siteId, "site");

--- a/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
@@ -53,6 +53,7 @@ public class SiteProcessorImpl implements ISiteProcessor {
     List<SiteEntriesRecord> records =
         db.selectFrom(SITE_ENTRIES)
             .where(SITE_ENTRIES.SITE_ID.eq(siteId))
+            .and(SITE_ENTRIES.DELETED_AT.isNull())
             .orderBy(SITE_ENTRIES.CREATED_AT.desc())
             .fetch();
 


### PR DESCRIPTION
## Why

Resolves #211 

Allow admins to delete site entries, such as if they are old/obsolete

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

- Adds the `deleted_at` column to the `site_entries` table
- Adds a route to soft-delete entries by setting the `deleted_at` column
- Update the get site route to only fetch non-deleted entries

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

## Verification Steps

- Verified that deleting the route set the `deleted_at` field
- Verified that the route returns an error if there are no other entries
- Verified on the site that deleted entries don't show up

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->
