### PR TITLE
Ot.rate limit v2 (Bucket4j server side throttling)

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -26,6 +26,12 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j-core</artifactId>
+            <version>8.0.1</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/api/src/main/java/com/codeforcommunity/api/IProtectedEmailerProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedEmailerProcessor.java
@@ -3,7 +3,6 @@ package com.codeforcommunity.api;
 import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dto.emailer.AddTemplateRequest;
 import com.codeforcommunity.dto.emailer.LoadTemplateResponse;
-
 import java.util.List;
 
 public interface IProtectedEmailerProcessor {

--- a/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProtectedSiteProcessor.java
@@ -19,11 +19,9 @@ import com.codeforcommunity.dto.site.ReportSiteRequest;
 import com.codeforcommunity.dto.site.SiteEntryImage;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import com.codeforcommunity.dto.site.UploadSiteImageRequest;
-
-import org.simplejavamail.api.email.AttachmentResource;
-
 import java.sql.Date;
 import java.util.List;
+import org.simplejavamail.api.email.AttachmentResource;
 
 public interface IProtectedSiteProcessor {
 
@@ -131,8 +129,10 @@ public interface IProtectedSiteProcessor {
   /** Edits the site entry with the given entryId */
   void editSiteEntry(JWTData userData, int entryId, UpdateSiteRequest editSiteEntryRequest);
 
-  /** Rejects the site image (deletes and sends an email with a rejection reason and the
-   * rejected image to the uploader's email) with the given imageId */
+  /**
+   * Rejects the site image (deletes and sends an email with a rejection reason and the rejected
+   * image to the uploader's email) with the given imageId
+   */
   void rejectSiteImage(JWTData userData, int imageId, String rejectionReason);
 
   List<SiteEntryImage> getUnapprovedImages(JWTData userData);
@@ -143,7 +143,7 @@ public interface IProtectedSiteProcessor {
   /** Reports the site for an issue by sending an email to SFTT */
   void reportSiteForIssues(JWTData userData, int siteId, ReportSiteRequest reportSiteRequest);
 
-  /** Loads a site image with the given ID as an attachment resource*/
+  /** Loads a site image with the given ID as an attachment resource */
   AttachmentResource loadSiteImage(JWTData userData, int imageId);
 
   /** Deletes the given site entry and associated data */

--- a/api/src/main/java/com/codeforcommunity/dto/emailer/EmailAttachment.java
+++ b/api/src/main/java/com/codeforcommunity/dto/emailer/EmailAttachment.java
@@ -4,100 +4,102 @@ import com.codeforcommunity.dto.ApiDto;
 import com.codeforcommunity.exceptions.BadRequestImageException;
 import com.codeforcommunity.exceptions.HandledException;
 import com.codeforcommunity.exceptions.MalformedParameterException;
-
-import org.simplejavamail.api.email.AttachmentResource;
-
-import javax.mail.util.ByteArrayDataSource;
-
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import javax.mail.util.ByteArrayDataSource;
+import org.simplejavamail.api.email.AttachmentResource;
 
 public class EmailAttachment extends ApiDto {
-    private String name;
-    private String data;
+  private String name;
+  private String data;
 
-    public EmailAttachment(String name, String data) {
-        this.name = name;
-        this.data = data;
+  public EmailAttachment(String name, String data) {
+    this.name = name;
+    this.data = data;
+  }
+
+  private EmailAttachment() {}
+
+  public static String getFileMimeType(String base64File) {
+    if (base64File == null || base64File.length() < 10) {
+      return null;
     }
 
-    private EmailAttachment() {}
-
-    public static String getFileMimeType(String base64File) {
-        if (base64File == null || base64File.length() < 10) {
-            return null;
-        }
-
-        String[] base64ImageSplit = base64File.split(",", 2);
-        if (base64ImageSplit.length != 2) {
-            return null;
-        }
-
-        String meta = base64ImageSplit[0];
-        String[] metaSplit = meta.split(";", 2);
-
-        if (metaSplit.length != 2 || !metaSplit[1].equals("base64")) {
-            return null;
-        }
-
-        String[] dataSplit = metaSplit[0].split(":", 2);
-
-        if (dataSplit.length != 2) {
-            return null;
-        }
-
-        String fileExtension = dataSplit[1];
-        return fileExtension;
-    }
-    private static ByteArrayDataSource stringToDataSource(String data) {
-        byte[] imageData;
-        String mimeType;
-
-        try {
-            mimeType = getFileMimeType(data);
-            if (mimeType==null) {
-                throw new MalformedParameterException("data");
-            }
-
-            String[] base64Split = data.split(",", 2);
-            imageData = Base64.getDecoder().decode(base64Split[1]);
-
-        } catch (IllegalArgumentException e) {
-            // The image failed to decode
-            throw new BadRequestImageException();
-        }
-        return new ByteArrayDataSource(imageData, mimeType);
+    String[] base64ImageSplit = base64File.split(",", 2);
+    if (base64ImageSplit.length != 2) {
+      return null;
     }
 
-    public String getName() {
-        return name;
+    String meta = base64ImageSplit[0];
+    String[] metaSplit = meta.split(";", 2);
+
+    if (metaSplit.length != 2 || !metaSplit[1].equals("base64")) {
+      return null;
     }
 
-    public void setName(String name) { this.name = name; }
+    String[] dataSplit = metaSplit[0].split(":", 2);
 
-    public String getData() {
-        return data;
+    if (dataSplit.length != 2) {
+      return null;
     }
 
-    public void setData(String data) { this.data = data; }
+    String fileExtension = dataSplit[1];
+    return fileExtension;
+  }
 
-    public AttachmentResource getAttachmentResource() {
-        return new AttachmentResource(name, EmailAttachment.stringToDataSource(data));
+  private static ByteArrayDataSource stringToDataSource(String data) {
+    byte[] imageData;
+    String mimeType;
+
+    try {
+      mimeType = getFileMimeType(data);
+      if (mimeType == null) {
+        throw new MalformedParameterException("data");
+      }
+
+      String[] base64Split = data.split(",", 2);
+      imageData = Base64.getDecoder().decode(base64Split[1]);
+
+    } catch (IllegalArgumentException e) {
+      // The image failed to decode
+      throw new BadRequestImageException();
+    }
+    return new ByteArrayDataSource(imageData, mimeType);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getData() {
+    return data;
+  }
+
+  public void setData(String data) {
+    this.data = data;
+  }
+
+  public AttachmentResource getAttachmentResource() {
+    return new AttachmentResource(name, EmailAttachment.stringToDataSource(data));
+  }
+
+  @Override
+  public List<String> validateFields(String fieldPrefix) throws HandledException {
+    String fieldName = fieldPrefix + "email_attachment";
+    List<String> fields = new ArrayList<>();
+
+    if (this.name == null) {
+      fields.add(fieldName + "name");
+    }
+    if (this.data == null) {
+      fields.add(fieldName + "data");
     }
 
-    @Override
-    public List<String> validateFields(String fieldPrefix) throws HandledException {
-        String fieldName = fieldPrefix + "email_attachment";
-        List<String> fields = new ArrayList<>();
-
-        if (this.name == null) {
-            fields.add(fieldName + "name");
-        }
-        if (this.data == null) {
-            fields.add(fieldName + "data");
-        }
-
-        return fields;
-    }
+    return fields;
+  }
 }

--- a/api/src/main/java/com/codeforcommunity/dto/neighborhoods/SendEmailRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/neighborhoods/SendEmailRequest.java
@@ -3,8 +3,6 @@ package com.codeforcommunity.dto.neighborhoods;
 import com.codeforcommunity.dto.ApiDto;
 import com.codeforcommunity.dto.emailer.EmailAttachment;
 import com.codeforcommunity.exceptions.HandledException;
-import org.simplejavamail.api.email.AttachmentResource;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,8 +13,11 @@ public class SendEmailRequest extends ApiDto {
 
   private List<EmailAttachment> attachments;
 
-  public SendEmailRequest(List<String> emails, String emailSubject, String emailBody,
-                          List<EmailAttachment> attachments) {
+  public SendEmailRequest(
+      List<String> emails,
+      String emailSubject,
+      String emailBody,
+      List<EmailAttachment> attachments) {
     this.emails = emails;
     this.emailSubject = emailSubject;
     this.emailBody = emailBody;
@@ -44,8 +45,10 @@ public class SendEmailRequest extends ApiDto {
   public List<EmailAttachment> getAttachments() {
     return this.attachments;
   }
+
   public void setAttachments(List<EmailAttachment> attachments) {
-    this.attachments = attachments; }
+    this.attachments = attachments;
+  }
 
   public String getEmailSubject() {
     return this.emailSubject;

--- a/api/src/main/java/com/codeforcommunity/dto/site/FilterSiteImageRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/FilterSiteImageRequest.java
@@ -2,7 +2,6 @@ package com.codeforcommunity.dto.site;
 
 import com.codeforcommunity.dto.ApiDto;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;

--- a/api/src/main/java/com/codeforcommunity/dto/site/FilterSiteImageResponse.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/FilterSiteImageResponse.java
@@ -10,8 +10,10 @@ public class FilterSiteImageResponse {
   private int siteId;
   private String uploaderName;
   private String uploaderEmail;
+
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy")
   private Timestamp dateSubmitted;
+
   private String commonName;
   private int neighborhoodId;
   private String address;

--- a/api/src/main/java/com/codeforcommunity/dto/site/ManyAddSiteEntriesRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/ManyAddSiteEntriesRequest.java
@@ -2,7 +2,6 @@ package com.codeforcommunity.dto.site;
 
 import com.codeforcommunity.dto.ApiDto;
 import com.codeforcommunity.exceptions.HandledException;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,7 +11,8 @@ public class ManyAddSiteEntriesRequest extends ApiDto {
 
   private List<Integer> sites;
 
-  public ManyAddSiteEntriesRequest(List<UpdateSiteRequest> updateSiteRequests, List<Integer> sites) {
+  public ManyAddSiteEntriesRequest(
+      List<UpdateSiteRequest> updateSiteRequests, List<Integer> sites) {
     this.updateSiteRequests = updateSiteRequests;
     this.sites = sites;
   }

--- a/api/src/main/java/com/codeforcommunity/dto/site/ManyEditSitesRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/ManyEditSitesRequest.java
@@ -2,7 +2,6 @@ package com.codeforcommunity.dto.site;
 
 import com.codeforcommunity.dto.ApiDto;
 import com.codeforcommunity.exceptions.HandledException;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/api/src/main/java/com/codeforcommunity/dto/site/RejectImageRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/site/RejectImageRequest.java
@@ -5,25 +5,25 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RejectImageRequest extends ApiDto {
-    private String rejectionReason;
+  private String rejectionReason;
 
-    public RejectImageRequest(String rejectionReason) {
-        this.rejectionReason = rejectionReason;
-    }
+  public RejectImageRequest(String rejectionReason) {
+    this.rejectionReason = rejectionReason;
+  }
 
-    private RejectImageRequest() {}
+  private RejectImageRequest() {}
 
-    public String getRejectionReason() {
-        return rejectionReason;
-    }
+  public String getRejectionReason() {
+    return rejectionReason;
+  }
 
-    public void setNewReason(String newEmail) {
-        this.rejectionReason = rejectionReason;
-    }
+  public void setNewReason(String newEmail) {
+    this.rejectionReason = rejectionReason;
+  }
 
-    @Override
-    public List<String> validateFields(String fieldPrefix) {
-        List<String> fields = new ArrayList<>();
-        return fields;
-    }
+  @Override
+  public List<String> validateFields(String fieldPrefix) {
+    List<String> fields = new ArrayList<>();
+    return fields;
+  }
 }

--- a/api/src/main/java/com/codeforcommunity/rest/IRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/IRouter.java
@@ -5,5 +5,5 @@ import io.vertx.ext.web.Router;
 
 public interface IRouter {
 
-  Router initializeRouter(Vertx vertx, IpThrottlingFilter filter);
+  Router initializeRouter(Vertx vertx);
 }

--- a/api/src/main/java/com/codeforcommunity/rest/IRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/IRouter.java
@@ -5,5 +5,5 @@ import io.vertx.ext.web.Router;
 
 public interface IRouter {
 
-  Router initializeRouter(Vertx vertx);
+  Router initializeRouter(Vertx vertx, IpThrottlingFilter filter);
 }

--- a/api/src/main/java/com/codeforcommunity/rest/IpThrottlingFilter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/IpThrottlingFilter.java
@@ -1,0 +1,39 @@
+package com.codeforcommunity.rest;
+
+import static com.codeforcommunity.rest.ApiRouter.end;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.TokensInheritanceStrategy;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+public class IpThrottlingFilter implements Handler<RoutingContext> {
+  private final BucketConfiguration config;
+  private Map<String, Bucket> buckets;
+
+  public IpThrottlingFilter(BucketConfiguration config) {
+    this.config = config;
+    this.buckets = new HashMap<>();
+  }
+
+  @Override
+  public void handle(RoutingContext ctx) {
+    String ip = ctx.request().remoteAddress().toString();
+    Bucket bucket = this.buckets.get(ip);
+
+    if (bucket == null) {
+      bucket = Bucket.builder().build();
+      bucket.replaceConfiguration(this.config, TokensInheritanceStrategy.RESET);
+      this.buckets.put(ip, bucket);
+    }
+
+    if (bucket.tryConsume(1)) {
+      ctx.next();
+    } else {
+      end(ctx.response(), 429, "Too many requests", "text/plain");
+    }
+  }
+}

--- a/api/src/main/java/com/codeforcommunity/rest/IpThrottlingFilter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/IpThrottlingFilter.java
@@ -1,14 +1,14 @@
 package com.codeforcommunity.rest;
 
 import static com.codeforcommunity.rest.ApiRouter.end;
-import java.util.HashMap;
-import java.util.Map;
 
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.BucketConfiguration;
 import io.github.bucket4j.TokensInheritanceStrategy;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
+import java.util.HashMap;
+import java.util.Map;
 
 public class IpThrottlingFilter implements Handler<RoutingContext> {
   private final BucketConfiguration config;
@@ -22,7 +22,9 @@ public class IpThrottlingFilter implements Handler<RoutingContext> {
   @Override
   public void handle(RoutingContext ctx) {
     String ip = ctx.request().remoteAddress().toString();
+    System.out.println(buckets);
     Bucket bucket = this.buckets.get(ip);
+    System.out.println(bucket);
 
     if (bucket == null) {
       bucket = Bucket.builder().build();

--- a/api/src/main/java/com/codeforcommunity/rest/IpThrottlingFilter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/IpThrottlingFilter.java
@@ -2,11 +2,14 @@ package com.codeforcommunity.rest;
 
 import static com.codeforcommunity.rest.ApiRouter.end;
 
+import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.BucketConfiguration;
 import io.github.bucket4j.TokensInheritanceStrategy;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
+
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,13 +25,10 @@ public class IpThrottlingFilter implements Handler<RoutingContext> {
   @Override
   public void handle(RoutingContext ctx) {
     String ip = ctx.request().remoteAddress().toString();
-    System.out.println(buckets);
     Bucket bucket = this.buckets.get(ip);
-    System.out.println(bucket);
 
     if (bucket == null) {
-      bucket = Bucket.builder().build();
-      bucket.replaceConfiguration(this.config, TokensInheritanceStrategy.RESET);
+      bucket = Bucket.builder().addLimit(this.config.getBandwidths()[0]).build();
       this.buckets.put(ip, bucket);
     }
 

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
@@ -7,7 +7,6 @@ import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dto.emailer.AddTemplateRequest;
 import com.codeforcommunity.dto.emailer.LoadTemplateResponse;
 import com.codeforcommunity.rest.IRouter;
-import com.codeforcommunity.rest.IpThrottlingFilter;
 import com.codeforcommunity.rest.RestFunctions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -26,9 +25,8 @@ public class ProtectedEmailerRouter implements IRouter {
   }
 
   @Override
-  public Router initializeRouter(Vertx vertx, IpThrottlingFilter filter) {
+  public Router initializeRouter(Vertx vertx) {
     Router router = Router.router(vertx);
-    router.route().handler(filter);
 
     registerAddTemplate(router);
     registerLoadTemplate(router);

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedEmailerRouter.java
@@ -7,16 +7,15 @@ import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dto.emailer.AddTemplateRequest;
 import com.codeforcommunity.dto.emailer.LoadTemplateResponse;
 import com.codeforcommunity.rest.IRouter;
+import com.codeforcommunity.rest.IpThrottlingFilter;
 import com.codeforcommunity.rest.RestFunctions;
-
-import java.util.Collections;
-import java.util.List;
-
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import java.util.Collections;
+import java.util.List;
 
 public class ProtectedEmailerRouter implements IRouter {
 
@@ -27,8 +26,9 @@ public class ProtectedEmailerRouter implements IRouter {
   }
 
   @Override
-  public Router initializeRouter(Vertx vertx) {
+  public Router initializeRouter(Vertx vertx, IpThrottlingFilter filter) {
     Router router = Router.router(vertx);
+    router.route().handler(filter);
 
     registerAddTemplate(router);
     registerLoadTemplate(router);
@@ -91,8 +91,8 @@ public class ProtectedEmailerRouter implements IRouter {
 
     List<String> names = processor.loadTemplateNames(userData);
     end(
-            ctx.response(),
-            200,
-            JsonObject.mapFrom(Collections.singletonMap("templates", names)).toString());
+        ctx.response(),
+        200,
+        JsonObject.mapFrom(Collections.singletonMap("templates", names)).toString());
   }
 }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/ProtectedSiteRouter.java
@@ -23,7 +23,6 @@ import com.codeforcommunity.dto.site.ReportSiteRequest;
 import com.codeforcommunity.dto.site.SiteEntryImage;
 import com.codeforcommunity.dto.site.UpdateSiteRequest;
 import com.codeforcommunity.dto.site.UploadSiteImageRequest;
-import com.codeforcommunity.exceptions.MissingParameterException;
 import com.codeforcommunity.rest.IRouter;
 import com.codeforcommunity.rest.RestFunctions;
 import io.vertx.core.Vertx;
@@ -421,8 +420,8 @@ public class ProtectedSiteRouter implements IRouter {
     JWTData userData = ctx.get("jwt_data");
     int imageId = RestFunctions.getRequestParameterAsInt(ctx.request(), "image_id");
     String defaultRejectionReason = "Your image upload was rejected by an admin";
-    Optional<String> rejectionReason = RestFunctions.getOptionalQueryParam(
-            ctx, "reason", Function.identity());
+    Optional<String> rejectionReason =
+        RestFunctions.getOptionalQueryParam(ctx, "reason", Function.identity());
 
     processor.rejectSiteImage(userData, imageId, rejectionReason.orElse(defaultRejectionReason));
 
@@ -542,7 +541,8 @@ public class ProtectedSiteRouter implements IRouter {
   private void handleAddManySiteEntries(RoutingContext ctx) {
     JWTData userData = ctx.get("jwt_data");
 
-    ManyAddSiteEntriesRequest req = RestFunctions.getJsonBodyAsClass(ctx, ManyAddSiteEntriesRequest.class);
+    ManyAddSiteEntriesRequest req =
+        RestFunctions.getJsonBodyAsClass(ctx, ManyAddSiteEntriesRequest.class);
 
     processor.addManySiteEntries(userData, req);
 

--- a/common/src/main/java/com/codeforcommunity/email/EmailOperations.java
+++ b/common/src/main/java/com/codeforcommunity/email/EmailOperations.java
@@ -4,7 +4,6 @@ import com.codeforcommunity.logger.SLogger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -17,7 +16,6 @@ import org.simplejavamail.api.mailer.Mailer;
 import org.simplejavamail.api.mailer.config.TransportStrategy;
 import org.simplejavamail.email.EmailBuilder;
 import org.simplejavamail.mailer.MailerBuilder;
-
 
 public class EmailOperations {
   private final SLogger logger = new SLogger(EmailOperations.class);
@@ -152,15 +150,19 @@ public class EmailOperations {
   }
 
   private Email buildEmailSingleRecipient(
-          String sendToName, String sendToEmail, String subject, String emailBody, List<AttachmentResource> attachments) {
+      String sendToName,
+      String sendToEmail,
+      String subject,
+      String emailBody,
+      List<AttachmentResource> attachments) {
     Email email =
-            EmailBuilder.startingBlank()
-                    .from(senderName, sendEmail)
-                    .to(sendToName, sendToEmail)
-                    .withSubject(subject)
-                    .withHTMLText(emailBody)
-                    .withAttachments(attachments)
-                    .buildEmail();
+        EmailBuilder.startingBlank()
+            .from(senderName, sendEmail)
+            .to(sendToName, sendToEmail)
+            .withSubject(subject)
+            .withHTMLText(emailBody)
+            .withAttachments(attachments)
+            .buildEmail();
 
     return email;
   }
@@ -170,32 +172,46 @@ public class EmailOperations {
    * email with attachments.
    */
   public void sendEmailToOneRecipient(
-          String sendToName, String sendToEmail, String subject, String emailBody, List<AttachmentResource> attachments) {
+      String sendToName,
+      String sendToEmail,
+      String subject,
+      String emailBody,
+      List<AttachmentResource> attachments) {
     if (!shouldSendEmails) {
       return;
     }
     logger.info(String.format("Sending email with subject `%s`", subject));
-    Email email = buildEmailSingleRecipient(sendToName, sendToEmail, subject, emailBody, attachments);
+    Email email =
+        buildEmailSingleRecipient(sendToName, sendToEmail, subject, emailBody, attachments);
     this.sendEmail(email, subject);
   }
 
   private Email buildEmailMultipleRecipient(
-          HashSet<String> sendToEmails, String subject, String emailBody, List<AttachmentResource> attachments) {
+      HashSet<String> sendToEmails,
+      String subject,
+      String emailBody,
+      List<AttachmentResource> attachments) {
     Email email =
-            EmailBuilder.startingBlank()
-                    .from(senderName, sendEmail)
-                    .bccMultiple(sendToEmails.toArray(new String[0]))
-                    .withSubject(subject)
-                    .withHTMLText(emailBody)
-                    .withAttachments(attachments)
-                    .buildEmail();
+        EmailBuilder.startingBlank()
+            .from(senderName, sendEmail)
+            .bccMultiple(sendToEmails.toArray(new String[0]))
+            .withSubject(subject)
+            .withHTMLText(emailBody)
+            .withAttachments(attachments)
+            .buildEmail();
 
     return email;
   }
 
-  /** Send an email with the given subject and body to the users with the given email addresses with attachments. */
+  /**
+   * Send an email with the given subject and body to the users with the given email addresses with
+   * attachments.
+   */
   public void sendEmailToMultipleRecipients(
-      HashSet<String> sendToEmails, String subject, String emailBody, List<AttachmentResource> attachments) {
+      HashSet<String> sendToEmails,
+      String subject,
+      String emailBody,
+      List<AttachmentResource> attachments) {
     if (!shouldSendEmails) {
       return;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jooq-version>3.12.4</jooq-version>
     <javamail-version>6.0.3</javamail-version>
     <flyway-version>7.2.0</flyway-version>
+    <jcache-version>1.1.1</jcache-version>
   </properties>
   <build>
     <defaultGoal>clean install</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jooq-version>3.12.4</jooq-version>
     <javamail-version>6.0.3</javamail-version>
     <flyway-version>7.2.0</flyway-version>
-    <jcache-version>1.1.1</jcache-version>
   </properties>
   <build>
     <defaultGoal>clean install</defaultGoal>

--- a/service/src/main/java/com/codeforcommunity/ServiceMain.java
+++ b/service/src/main/java/com/codeforcommunity/ServiceMain.java
@@ -45,8 +45,8 @@ import org.jooq.impl.DSL;
 
 public class ServiceMain {
   private DSLContext db;
-  public static final long CAPACITY = 20;
-  public static final Refill REFILL = Refill.greedy(10, Duration.ofMinutes(1));
+  public static final long CAPACITY = 50;
+  public static final Refill REFILL = Refill.greedy(20, Duration.ofMinutes(1));
 
   public static void main(String[] args) {
     try {

--- a/service/src/main/java/com/codeforcommunity/ServiceMain.java
+++ b/service/src/main/java/com/codeforcommunity/ServiceMain.java
@@ -45,6 +45,8 @@ import org.jooq.impl.DSL;
 
 public class ServiceMain {
   private DSLContext db;
+  public static final long CAPACITY = 20;
+  public static final Refill REFILL = Refill.greedy(10, Duration.ofMinutes(1));
 
   public static void main(String[] args) {
     try {
@@ -122,8 +124,6 @@ public class ServiceMain {
         new ProtectedNeighborhoodsProcessorImpl(this.db, emailer);
     IProtectedEmailerProcessor emailerProc = new ProtectedEmailerProcessorImpl(this.db);
 
-    long CAPACITY = 2;
-    Refill REFILL = Refill.greedy(1, Duration.ofMinutes(1));
     Bandwidth bandwidth = Bandwidth.classic(CAPACITY, REFILL);
     BucketConfiguration configuration = BucketConfiguration.builder().addLimit(bandwidth).build();
     IpThrottlingFilter filter = new IpThrottlingFilter(configuration);

--- a/service/src/main/java/com/codeforcommunity/ServiceMain.java
+++ b/service/src/main/java/com/codeforcommunity/ServiceMain.java
@@ -33,7 +33,12 @@ import com.codeforcommunity.processor.TeamsProcessorImpl;
 import com.codeforcommunity.propertiesLoader.PropertiesLoader;
 import com.codeforcommunity.requester.Emailer;
 import com.codeforcommunity.rest.ApiRouter;
+import com.codeforcommunity.rest.IpThrottlingFilter;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.Refill;
 import io.vertx.core.Vertx;
+import java.time.Duration;
 import java.util.Properties;
 import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
@@ -117,6 +122,12 @@ public class ServiceMain {
         new ProtectedNeighborhoodsProcessorImpl(this.db, emailer);
     IProtectedEmailerProcessor emailerProc = new ProtectedEmailerProcessorImpl(this.db);
 
+    long CAPACITY = 2;
+    Refill REFILL = Refill.greedy(1, Duration.ofMinutes(1));
+    Bandwidth bandwidth = Bandwidth.classic(CAPACITY, REFILL);
+    BucketConfiguration configuration = BucketConfiguration.builder().addLimit(bandwidth).build();
+    IpThrottlingFilter filter = new IpThrottlingFilter(configuration);
+
     // Create the API router and start the HTTP server
     ApiRouter router =
         new ApiRouter(
@@ -133,7 +144,8 @@ public class ServiceMain {
             reportProc,
             protectedNeighborhoodsProc,
             emailerProc,
-            jwtAuthorizer);
+            jwtAuthorizer,
+            filter);
 
     startApiServer(router, vertx);
   }

--- a/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/MapProcessorImpl.java
@@ -295,7 +295,8 @@ public class MapProcessorImpl implements IMapProcessor {
   private static class SiteGeoResponseCache {
     private static SiteGeoResponse response;
     private static long expireTime = 0;
-    private static final long timeToLive = 20 * 1000; // in milliseconds, 5000 is the avg. response time
+    private static final long timeToLive =
+        20 * 1000; // in milliseconds, 5000 is the avg. response time
 
     public static SiteGeoResponse getResponse() {
       return response;

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedEmailerProcessorImpl.java
@@ -9,10 +9,9 @@ import com.codeforcommunity.dto.emailer.LoadTemplateResponse;
 import com.codeforcommunity.exceptions.UserDoesNotExistException;
 import com.codeforcommunity.propertiesLoader.PropertiesLoader;
 import com.codeforcommunity.requester.S3Requester;
+import java.util.List;
 import org.jooq.DSLContext;
 import org.jooq.generated.tables.records.UsersRecord;
-
-import java.util.List;
 
 public class ProtectedEmailerProcessorImpl extends AbstractProcessor
     implements IProtectedEmailerProcessor {
@@ -57,7 +56,8 @@ public class ProtectedEmailerProcessorImpl extends AbstractProcessor
   @Override
   public List<String> loadTemplateNames(JWTData userData) {
     assertAdminOrSuperAdmin(userData.getPrivilegeLevel());
-    List<String> names = S3Requester.getAllNamesinBucket(PropertiesLoader.loadProperty("aws_s3_bucket_name"));
+    List<String> names =
+        S3Requester.getAllNamesinBucket(PropertiesLoader.loadProperty("aws_s3_bucket_name"));
     return names;
   }
 }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedNeighborhoodsProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedNeighborhoodsProcessorImpl.java
@@ -9,11 +9,9 @@ import com.codeforcommunity.dto.neighborhoods.SendEmailRequest;
 import com.codeforcommunity.exceptions.MalformedParameterException;
 import com.codeforcommunity.exceptions.ResourceDoesNotExistException;
 import com.codeforcommunity.requester.Emailer;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-
 import org.jooq.DSLContext;
 import org.jooq.generated.tables.records.NeighborhoodsRecord;
 import org.simplejavamail.api.email.AttachmentResource;

--- a/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/SiteProcessorImpl.java
@@ -255,8 +255,8 @@ public class SiteProcessorImpl implements ISiteProcessor {
 
   @Override
   public GetSiteResponse getSite(int siteId) {
-    SitesRecord sitesRecord = db.selectFrom(SITES).where(SITES.ID.eq(siteId))
-            .and(SITES.DELETED_AT.isNull()).fetchOne();
+    SitesRecord sitesRecord =
+        db.selectFrom(SITES).where(SITES.ID.eq(siteId)).and(SITES.DELETED_AT.isNull()).fetchOne();
 
     if (sitesRecord == null) {
       throw new ResourceDoesNotExistException(siteId, "site");

--- a/service/src/main/java/com/codeforcommunity/processor/TeamsProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/TeamsProcessorImpl.java
@@ -234,7 +234,7 @@ public class TeamsProcessorImpl implements ITeamsProcessor {
   @Override
   public UsersResponse getApplicants(JWTData userData, int teamId) {
     checkTeamExists(teamId);
-    UsersTeamsRecord usersTeamsRecord = getUsersLeadTeams(userData, teamId); 
+    UsersTeamsRecord usersTeamsRecord = getUsersLeadTeams(userData, teamId);
 
     if (usersTeamsRecord != null) {
       return getUsers(teamId, TeamRole.PENDING);

--- a/service/src/main/java/com/codeforcommunity/requester/Emailer.java
+++ b/service/src/main/java/com/codeforcommunity/requester/Emailer.java
@@ -1,11 +1,9 @@
 package com.codeforcommunity.requester;
 
-import com.codeforcommunity.dto.emailer.EmailAttachment;
 import com.codeforcommunity.email.EmailOperations;
 import com.codeforcommunity.propertiesLoader.PropertiesLoader;
-import org.simplejavamail.api.email.AttachmentResource;
-
 import java.util.*;
+import org.simplejavamail.api.email.AttachmentResource;
 
 public class Emailer {
   private final EmailOperations emailOperations;
@@ -46,7 +44,7 @@ public class Emailer {
     this.frontendUrl = PropertiesLoader.loadProperty("frontend_base_url");
     this.passwordResetTemplate =
         this.frontendUrl + PropertiesLoader.loadProperty("frontend_password_reset_route");
-  } 
+  }
 
   public void sendWelcomeEmail(String sendToEmail, String sendToName) {
     String filePath = "/emails/WelcomeEmail.html";
@@ -58,7 +56,9 @@ public class Emailer {
     Optional<String> emailBody = emailOperations.getTemplateString(filePath, templateValues);
 
     emailBody.ifPresent(
-        s -> emailOperations.sendEmailToOneRecipient(sendToName, sendToEmail, subjectWelcome, s, new ArrayList<>()));
+        s ->
+            emailOperations.sendEmailToOneRecipient(
+                sendToName, sendToEmail, subjectWelcome, s, new ArrayList<>()));
   }
 
   public void sendEmailChangeConfirmationEmail(
@@ -127,7 +127,8 @@ public class Emailer {
     // TODO implement this
   }
 
-  public void sendRejectImageEmail(String sendToEmail, String sendToName, String reason, AttachmentResource rejectedImage) {
+  public void sendRejectImageEmail(
+      String sendToEmail, String sendToName, String reason, AttachmentResource rejectedImage) {
     String filePath = "/emails/RejectImageEmail.html";
 
     Map<String, String> templateValues = new HashMap<>();
@@ -135,9 +136,9 @@ public class Emailer {
     Optional<String> emailBody = emailOperations.getTemplateString(filePath, templateValues);
     List<AttachmentResource> attachments = Arrays.asList(rejectedImage);
     emailBody.ifPresent(
-            s ->
-                    emailOperations.sendEmailToOneRecipient(
-                            sendToName, sendToEmail, subjectImageRejected, s, attachments));
+        s ->
+            emailOperations.sendEmailToOneRecipient(
+                sendToName, sendToEmail, subjectImageRejected, s, attachments));
   }
 
   public void sendIssueReportEmail(
@@ -167,8 +168,11 @@ public class Emailer {
                 senderName, reportEmailDestination, subjectSiteReport, s, new ArrayList<>()));
   }
 
-  public void sendArbitraryEmail(HashSet<String> sendToEmails, String subject, String body,
-                                 List<AttachmentResource> attachments) {
+  public void sendArbitraryEmail(
+      HashSet<String> sendToEmails,
+      String subject,
+      String body,
+      List<AttachmentResource> attachments) {
     String filePath = "/emails/Email.html";
 
     Map<String, String> templateValues = new HashMap<>();
@@ -176,6 +180,8 @@ public class Emailer {
     Optional<String> emailBody = emailOperations.getTemplateString(filePath, templateValues);
 
     emailBody.ifPresent(
-        email -> emailOperations.sendEmailToMultipleRecipients(sendToEmails, subject, email, attachments));
+        email ->
+            emailOperations.sendEmailToMultipleRecipients(
+                sendToEmails, subject, email, attachments));
   }
 }

--- a/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
+++ b/service/src/main/java/com/codeforcommunity/requester/S3Requester.java
@@ -1,6 +1,5 @@
 package com.codeforcommunity.requester;
 
-import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -14,18 +13,13 @@ import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.codeforcommunity.aws.EncodedImage;
 import com.codeforcommunity.dto.emailer.LoadTemplateResponse;
 import com.codeforcommunity.exceptions.BadRequestHTMLException;
 import com.codeforcommunity.exceptions.BadRequestImageException;
 import com.codeforcommunity.exceptions.InvalidURLException;
-import com.codeforcommunity.exceptions.MalformedParameterException;
 import com.codeforcommunity.exceptions.S3FailedUploadException;
 import com.codeforcommunity.propertiesLoader.PropertiesLoader;
-
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -34,17 +28,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import org.jsoup.Jsoup;
 import org.jsoup.parser.ParseError;
 import org.jsoup.parser.ParseErrorList;
 import org.jsoup.parser.Parser;
-import org.simplejavamail.api.email.AttachmentResource;
-
-import javax.activation.DataSource;
-import javax.mail.util.ByteArrayDataSource;
-
-import software.amazon.ion.IonException;
 
 public class S3Requester {
   // Contains information about S3 that is not part of this class's implementation
@@ -408,7 +395,6 @@ public class S3Requester {
   }
 
   /**
-   *
    * @param bucketName
    * @return
    */
@@ -416,7 +402,7 @@ public class S3Requester {
     ListObjectsV2Request req = new ListObjectsV2Request();
     req.setBucketName(bucketName);
     req.setDelimiter("/");
-    String path = String.join("/", TEMPLATE_S3_DIR, externs.getDirPublic()+"/");
+    String path = String.join("/", TEMPLATE_S3_DIR, externs.getDirPublic() + "/");
     req.setPrefix(path);
     req.setStartAfter(path);
 
@@ -426,13 +412,13 @@ public class S3Requester {
       res = externs.getS3Client().listObjectsV2(req);
       String prefix = req.getPrefix();
       List<String> result;
-      result = res.getObjectSummaries().stream().map(s -> s.getKey().replace(prefix, "").replace("_template.html", "")).collect(Collectors.toList());
+      result =
+          res.getObjectSummaries().stream()
+              .map(s -> s.getKey().replace(prefix, "").replace("_template.html", ""))
+              .collect(Collectors.toList());
       return result;
     } catch (SdkClientException a) {
       throw new InvalidURLException();
     }
   }
-
-
-
 }


### PR DESCRIPTION
## Why

Resolves #<ticket number here>

Implements server-side IP-specific token bucket API throttling to prevent server overload from massive popularity or DOS attack.

## This PR

IpThrottlingFilter class instance acts as a VertX handler and intercepts all API calls before they get forwarded to processors. Keeps a hash map of IP addresses to buckets. Adds new buckets if new IP address. Uses bucket4j library.

Currently there is only one throttling class instance, so it is a globally-aggregated token consumption per IP. If we wanted to throttle per router or per route, we would create separate filter class instances for each route(r).

These are subject to change, but initial capacity is 20 and refills tokens at 10/min greedily (1 token every 6 sec) . One API route call consumes one token.

Service main contains these constants, creates an IpThrottlingFilter instance with the config (with the constants) and passes it to ApiRouter. The instance gets mounted to the common and protected router. If we wanted to to lower route(r) level throttling, we would create individual instances for each route(r) during subrouter initialization or instantiation.

## Verification Steps

Postman spamming to ensure that you get 429 error. Localhost reload spamming to get 429 error. Frontend might want to display different message when 429 occurs (Too many requests)?

<img width="972" alt="Screenshot 2024-07-19 at 4 39 05 PM" src="https://github.com/user-attachments/assets/d3f90c34-b4f0-4c1b-bb20-571051b84134">
<img width="1111" alt="Screenshot 2024-07-19 at 4 39 56 PM" src="https://github.com/user-attachments/assets/b8dd7a6a-ca59-4e80-8303-178db3f6d329">

